### PR TITLE
T/139a: getOptimalPosition() utility does not work when the parent element has a scroll

### DIFF
--- a/src/dom/position.js
+++ b/src/dom/position.js
@@ -109,7 +109,7 @@ export function getOptimalPosition( { element, target, positions, limiter, fitIn
 		left -= ancestorPosition.left;
 		top -= ancestorPosition.top;
 
-		// (https://github.com/ckeditor/ckeditor5-utils/tree/t/139)
+		// (https://github.com/ckeditor/ckeditor5-utils/issues/139)
 		// If there's some positioned ancestor of the panel, not only its position must be taken into
 		// consideration (see above) but also its internal scrolls. Scroll have an impact here because `Rect`
 		// is relative to the viewport (it doesn't care about scrolling), while `position: absolute`
@@ -117,7 +117,7 @@ export function getOptimalPosition( { element, target, positions, limiter, fitIn
 		left += positionedElementAncestor.scrollLeft;
 		top += positionedElementAncestor.scrollTop;
 
-		// (https://github.com/ckeditor/ckeditor5-utils/tree/t/139)
+		// (https://github.com/ckeditor/ckeditor5-utils/issues/139)
 		// If there's some positioned ancestor of the panel, then its `Rect` includes its CSS `borderWidth`
 		// while `position: absolute` positioning does not consider it.
 		// E.g. `{ position: absolute, top: 0, left: 0 }` means upper left corner of the element,

--- a/src/dom/position.js
+++ b/src/dom/position.js
@@ -103,7 +103,8 @@ export function getOptimalPosition( { element, target, positions, limiter, fitIn
 		const ancestorPosition = getAbsoluteRectCoordinates( new Rect( positionedElementAncestor ) );
 		const ancestorComputedStyles = global.window.getComputedStyle( positionedElementAncestor );
 
-		// (#126) If there's some positioned ancestor of the panel, then its `Rect` must be taken into
+		// (https://github.com/ckeditor/ckeditor5-ui-default/issues/126)
+		// If there's some positioned ancestor of the panel, then its `Rect` must be taken into
 		// consideration. `Rect` is always relative to the viewport while `position: absolute` works
 		// with respect to that positioned ancestor.
 		left -= ancestorPosition.left;

--- a/src/dom/position.js
+++ b/src/dom/position.js
@@ -99,14 +99,29 @@ export function getOptimalPosition( { element, target, positions, limiter, fitIn
 
 	let { left, top } = getAbsoluteRectCoordinates( bestPosition );
 
-	// (#126) If there's some positioned ancestor of the panel, then its rect must be taken into
-	// consideration. `Rect` is always relative to the viewport while `position: absolute` works
-	// with respect to that positioned ancestor.
 	if ( positionedElementAncestor ) {
 		const ancestorPosition = getAbsoluteRectCoordinates( new Rect( positionedElementAncestor ) );
+		const ancestorComputedStyles = global.window.getComputedStyle( positionedElementAncestor );
 
+		// (#126) If there's some positioned ancestor of the panel, then its rect must be taken into
+		// consideration. `Rect` is always relative to the viewport while `position: absolute` works
+		// with respect to that positioned ancestor.
 		left -= ancestorPosition.left;
 		top -= ancestorPosition.top;
+
+		// (https://github.com/ckeditor/ckeditor5-utils/tree/t/139)
+		// If there's some positioned ancestor of the panel, not its position must be taken into
+		// consideration (see above) but also its internal scrolls. Scroll have an impact on Rect which,
+		// again, is relative to the viewport, while position: absolute includes scrolling.
+		left += positionedElementAncestor.scrollLeft;
+		top += positionedElementAncestor.scrollTop;
+
+		// (https://github.com/ckeditor/ckeditor5-utils/tree/t/139)
+		// If there's some positioned ancestor of the panel, then its rect contains it's border
+		// while `position: absolute` positioning does not consider it. E.g. { top: 0, left: 0 }
+		// means upper left corner of the element, not upper-left corner of its border.
+		left -= parseInt( ancestorComputedStyles.borderLeftWidth, 10 );
+		top -= parseInt( ancestorComputedStyles.borderTopWidth, 10 );
 	}
 
 	return { left, top, name };

--- a/src/dom/position.js
+++ b/src/dom/position.js
@@ -103,23 +103,25 @@ export function getOptimalPosition( { element, target, positions, limiter, fitIn
 		const ancestorPosition = getAbsoluteRectCoordinates( new Rect( positionedElementAncestor ) );
 		const ancestorComputedStyles = global.window.getComputedStyle( positionedElementAncestor );
 
-		// (#126) If there's some positioned ancestor of the panel, then its rect must be taken into
+		// (#126) If there's some positioned ancestor of the panel, then its `Rect` must be taken into
 		// consideration. `Rect` is always relative to the viewport while `position: absolute` works
 		// with respect to that positioned ancestor.
 		left -= ancestorPosition.left;
 		top -= ancestorPosition.top;
 
 		// (https://github.com/ckeditor/ckeditor5-utils/tree/t/139)
-		// If there's some positioned ancestor of the panel, not its position must be taken into
-		// consideration (see above) but also its internal scrolls. Scroll have an impact on Rect which,
-		// again, is relative to the viewport, while position: absolute includes scrolling.
+		// If there's some positioned ancestor of the panel, not only its position must be taken into
+		// consideration (see above) but also its internal scrolls. Scroll have an impact here because `Rect`
+		// is relative to the viewport (it doesn't care about scrolling), while `position: absolute`
+		// must compensate that scrolling.
 		left += positionedElementAncestor.scrollLeft;
 		top += positionedElementAncestor.scrollTop;
 
 		// (https://github.com/ckeditor/ckeditor5-utils/tree/t/139)
-		// If there's some positioned ancestor of the panel, then its rect contains it's border
-		// while `position: absolute` positioning does not consider it. E.g. { top: 0, left: 0 }
-		// means upper left corner of the element, not upper-left corner of its border.
+		// If there's some positioned ancestor of the panel, then its `Rect` includes its CSS `borderWidth`
+		// while `position: absolute` positioning does not consider it.
+		// E.g. `{ position: absolute, top: 0, left: 0 }` means upper left corner of the element,
+		// not upper-left corner of its border.
 		left -= parseInt( ancestorComputedStyles.borderLeftWidth, 10 );
 		top -= parseInt( ancestorComputedStyles.borderTopWidth, 10 );
 	}

--- a/tests/dom/position.js
+++ b/tests/dom/position.js
@@ -271,7 +271,7 @@ describe( 'getOptimalPosition()', () => {
 		} );
 
 		it( 'should return the very first coordinates if limiter does not fit into the viewport', () => {
-			getElement( limiter, {
+			limiter = getElement( {
 				top: -100,
 				right: -80,
 				bottom: -80,

--- a/tests/dom/position.js
+++ b/tests/dom/position.js
@@ -51,41 +51,103 @@ describe( 'getOptimalPosition', () => {
 			} );
 		} );
 
-		it( 'should return coordinates (positioned element parent)', () => {
-			const positionedParent = document.createElement( 'div' );
+		describe( 'positioned element parent', () => {
+			let positionedParent;
 
-			Object.assign( windowStub, {
-				innerWidth: 10000,
-				innerHeight: 10000,
-				scrollX: 1000,
-				scrollY: 1000,
-				getComputedStyle: ( el ) => {
-					return window.getComputedStyle( el );
-				}
+			beforeEach( () => {
+				positionedParent = document.createElement( 'div' );
+				document.body.appendChild( positionedParent );
 			} );
 
-			Object.assign( positionedParent.style, {
-				position: 'absolute',
-				top: '1000px',
-				left: '1000px'
+			afterEach( () => {
+				positionedParent.remove();
 			} );
 
-			document.body.appendChild( positionedParent );
-			positionedParent.appendChild( element );
+			it( 'should return coordinates', () => {
+				Object.assign( windowStub, {
+					innerWidth: 10000,
+					innerHeight: 10000,
+					scrollX: 1000,
+					scrollY: 1000,
+					getComputedStyle: ( el ) => {
+						return window.getComputedStyle( el );
+					}
+				} );
 
-			stubElementRect( positionedParent, {
-				top: 1000,
-				right: 1010,
-				bottom: 1010,
-				left: 1000,
-				width: 10,
-				height: 10
+				Object.assign( positionedParent.style, {
+					position: 'absolute',
+					top: '1000px',
+					left: '1000px'
+				} );
+
+				positionedParent.appendChild( element );
+
+				stubElementRect( positionedParent, {
+					top: 1000,
+					right: 1010,
+					bottom: 1010,
+					left: 1000,
+					width: 10,
+					height: 10
+				} );
+
+				assertPosition( { element, target, positions: [ attachLeft ] }, {
+					top: -900,
+					left: -920,
+					name: 'left'
+				} );
 			} );
 
-			assertPosition( { element, target, positions: [ attachLeft ] }, {
-				top: -900,
-				left: -920,
-				name: 'left'
+			it( 'should return coordinates (scroll and border)', () => {
+				const inflaterElement = document.createElement( 'div' );
+
+				Object.assign( windowStub, {
+					innerWidth: 10000,
+					innerHeight: 10000,
+					scrollX: 1000,
+					scrollY: 1000,
+					getComputedStyle: ( el ) => {
+						return window.getComputedStyle( el );
+					}
+				} );
+
+				positionedParent.appendChild( inflaterElement );
+				positionedParent.appendChild( element );
+
+				Object.assign( positionedParent.style, {
+					position: 'absolute',
+					overflow: 'scroll',
+					height: '100px',
+					width: '100px',
+					top: '0px',
+					left: '0px',
+					border: '1px solid red',
+					borderLeftWidth: '20px',
+					borderTopWidth: '40px',
+				} );
+
+				Object.assign( inflaterElement.style, {
+					width: '500px',
+					height: '500px'
+				} );
+
+				positionedParent.scrollTop = 100;
+				positionedParent.scrollLeft = 200;
+
+				stubElementRect( positionedParent, {
+					top: 0,
+					right: 10,
+					bottom: 10,
+					left: 0,
+					width: 10,
+					height: 10
+				} );
+
+				assertPosition( { element, target, positions: [ attachLeft ] }, {
+					top: 160,
+					left: 260,
+					name: 'left'
+				} );
 			} );
 		} );
 	} );

--- a/tests/manual/position/position.html
+++ b/tests/manual/position/position.html
@@ -1,0 +1,56 @@
+<div class="test-box" style="height: 200px; width: 200px">
+	<div class="test-box" style="height: 400px; width: 400px">
+		<div class="test-box" style="height: 800px; width: 800px">
+			<div class="target"></div>
+			<div class="source source-se"></div>
+		</div>
+		<div class="source source-sw"></div>
+	</div>
+	<div class="source source-ne"></div>
+</div>
+<div class="source source-nw"></div>
+
+<style>
+	body {
+		padding-top: 2000px;
+	}
+
+	.test-box {
+		padding: 15px;
+		border: 25px solid #000;
+		overflow: scroll;
+		position: relative;
+	}
+
+	.source {
+		width: 40px;
+		height: 40px;
+		background: red;
+		position: absolute;
+	}
+
+	.source-nw {
+		background: cyan;
+	}
+
+	.source-ne {
+		background: magenta;
+	}
+
+	.source-sw {
+		background: yellow;
+	}
+
+	.source-se {
+		background: black;
+	}
+
+	.target {
+		width: 80px;
+		height: 80px;
+		background: blue;
+		position: absolute;
+		bottom: 0;
+		right: 0;
+	}
+</style>

--- a/tests/manual/position/position.js
+++ b/tests/manual/position/position.js
@@ -1,0 +1,59 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* global document, setTimeout */
+
+import { getOptimalPosition } from '@ckeditor/ckeditor5-utils/src/dom/position';
+
+const boxes = document.querySelectorAll( '.test-box' );
+const sources = document.querySelectorAll( '.source' );
+const target = document.querySelector( '.target' );
+
+target.scrollIntoView();
+
+const positions = {
+	nw: ( targetRect ) => ( {
+		top: targetRect.top,
+		left: targetRect.left,
+		name: 'nw'
+	} ),
+	ne: ( targetRect, sourceRect ) => ( {
+		top: targetRect.top,
+		left: targetRect.right - sourceRect.width,
+		name: 'ne'
+	} ),
+	sw: ( targetRect, sourceRect ) => ( {
+		top: targetRect.bottom - sourceRect.height,
+		left: targetRect.left,
+		name: 'sw'
+	} ),
+	se: ( targetRect, sourceRect ) => ( {
+		top: targetRect.bottom - sourceRect.height,
+		left: targetRect.right - sourceRect.width,
+		name: 'se'
+	} )
+};
+
+for ( let box of boxes ) {
+	box.scrollTop = box.scrollHeight;
+	box.scrollLeft = box.scrollWidth;
+}
+
+// Wait for the scroll to stabilize.
+setTimeout( () => {
+	for ( let source of sources ) {
+		const position = getOptimalPosition( {
+			element: source,
+			target: target,
+			positions: [
+				positions[ source.className.split( '-' )[ 1 ] ]
+			],
+			limiter: document.body
+		} );
+
+		source.style.top = position.top + 'px';
+		source.style.left = position.left + 'px';
+	}
+}, 100 );

--- a/tests/manual/position/position.md
+++ b/tests/manual/position/position.md
@@ -1,0 +1,10 @@
+## getOptimalPosition() utility
+
+**Expected**: At the bottom of the page, in a nested, scrolled container hierarchy, a **perfect** square divided equally into 4 sub–squares should be visible.
+
+The colors of the sub–squares should be as follows:
+
+* Upper-left corner: <span style="color: cyan">cyan</span>,
+* Upper-right corner: <span style="color: magenta">magenta</span>,
+* Bottom-left corner: <span style="color: yellow; background: black;">yellow</span>,
+* Bottom-right corner: <span style="color: black">black</span>.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: getOptimalPosition() utility does not work when the parent element has a scroll. Closes #139.