### PR TITLE
Emitter#stopListening() and Emitter#off() improvements

### DIFF
--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -99,12 +99,12 @@ const EmitterMixin = {
 	},
 
 	/**
-	 * Stops executing the callback on the given event. It can be used at different levels:
+	 * Removes the callback for the given event. It can be used at different levels:
 	 *
-	 * To stop executing given callback, with given context.
-	 * To stop executing given callback.
-	 * To stop executing all callbacks for given event.
-	 * To stop executing all callbacks for this emitter.
+	 * * To stop executing given callback, with given context.
+	 * * To stop executing given callback.
+	 * * To stop executing all callbacks for given event.
+	 * * To stop executing all callbacks for this emitter.
 	 *
 	 * @method #off
 	 * @param {String} [event] The name of the event.
@@ -116,13 +116,13 @@ const EmitterMixin = {
 		if ( !event ) {
 			const events = getEvents( this );
 
-			for ( let event in events ) {
+			for ( const event in events ) {
 				this.off( event );
 			}
 		} else {
 			const lists = getCallbacksListsForNamespace( this, event );
 
-			for ( let callbacks of lists ) {
+			for ( const callbacks of lists ) {
 				for ( let i = 0; i < callbacks.length; i++ ) {
 					if ( !callback || callbacks[ i ].callback == callback ) {
 						if ( !context || context == callbacks[ i ].context ) {
@@ -198,8 +198,8 @@ const EmitterMixin = {
 	},
 
 	/**
-	 * Stops listening for events. If fired without any parameters, stops listening to all emitters and also stops
-	 * executing callbacks added by {@link module:utils/emittermixin~EmitterMixin#on on}.
+	 * Stops listening for events. If executed without any parameters, stops listening to all emitters, including
+	 * itself (so to the events added by {@link #on}).
 	 *
 	 * The method can be used at different levels:
 	 *
@@ -239,6 +239,7 @@ const EmitterMixin = {
 			while ( ( callback = eventCallbacks.pop() ) ) {
 				emitter.off( event, callback );
 			}
+
 			delete emitterInfo.callbacks[ event ];
 		}
 		// Only `emitter` provided. off() all events for that emitter.
@@ -246,6 +247,7 @@ const EmitterMixin = {
 			for ( event in emitterInfo.callbacks ) {
 				this.stopListening( emitter, event );
 			}
+
 			delete emitters[ emitterId ];
 		}
 		// No params provided. off() all emitters.
@@ -346,8 +348,8 @@ const EmitterMixin = {
 					this._delegations = new Map();
 				}
 
-				for ( let eventName of events ) {
-					let destinations = this._delegations.get( eventName );
+				for ( const eventName of events ) {
+					const destinations = this._delegations.get( eventName );
 
 					if ( !destinations ) {
 						this._delegations.set( eventName, new Map( [ [ emitter, nameOrFunction ] ] ) );

--- a/tests/emittermixin.js
+++ b/tests/emittermixin.js
@@ -377,6 +377,44 @@ describe( 'EmitterMixin', () => {
 			sinon.assert.calledTwice( spyBar );
 			sinon.assert.calledThrice( spyFoo2 );
 		} );
+
+		it( 'should remove all callbacks for given event name', () => {
+			let spyFoo = sinon.spy();
+			let spyBar = sinon.spy();
+			let spyAbc = sinon.spy();
+
+			emitter.on( 'foo', spyFoo );
+			emitter.on( 'foo:bar', spyBar );
+			emitter.on( 'abc', spyAbc );
+
+			emitter.off( 'foo' );
+
+			emitter.fire( 'foo' );
+			emitter.fire( 'abc' );
+
+			sinon.assert.notCalled( spyFoo );
+			sinon.assert.notCalled( spyBar );
+			sinon.assert.calledOnce( spyAbc );
+		} );
+
+		it( 'should remove all callbacks for all events', () => {
+			let spyFoo = sinon.spy();
+			let spyBar = sinon.spy();
+			let spyAbc = sinon.spy();
+
+			emitter.on( 'foo', spyFoo );
+			emitter.on( 'foo:bar', spyBar );
+			emitter.on( 'abc', spyAbc );
+
+			emitter.off();
+
+			emitter.fire( 'foo' );
+			emitter.fire( 'abc' );
+
+			sinon.assert.notCalled( spyFoo );
+			sinon.assert.notCalled( spyBar );
+			sinon.assert.notCalled( spyAbc );
+		} );
 	} );
 
 	describe( 'listenTo', () => {
@@ -520,6 +558,25 @@ describe( 'EmitterMixin', () => {
 
 			sinon.assert.notCalled( spyFoo );
 			sinon.assert.calledOnce( spyBar );
+		} );
+
+		it( 'should stop callbacks added by on()', () => {
+			let spyFoo = sinon.spy();
+			let spyBar = sinon.spy();
+			let spyAbc = sinon.spy();
+
+			emitter.on( 'foo', spyFoo );
+			emitter.on( 'foo:bar', spyBar );
+			emitter.on( 'abc', spyAbc );
+
+			emitter.stopListening();
+
+			emitter.fire( 'foo' );
+			emitter.fire( 'abc' );
+
+			sinon.assert.notCalled( spyFoo );
+			sinon.assert.notCalled( spyBar );
+			sinon.assert.notCalled( spyAbc );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `utils.Emitter#off()` called without arguments will stop executing all callbacks added by `utils.Emitter#on()`. Additionally, `utils.Emitter#stopListening()` called without arguments will also call `utils.Emitter#off()` thus stop all callbacks added by `utils.Emitter#on()`. Closes #144.