### PR TITLE
t/153: Rect utility should work for collapsed DOM Ranges. Closes #153.

### DIFF
--- a/src/dom/rect.js
+++ b/src/dom/rect.js
@@ -11,8 +11,6 @@ import global from './global';
 import isRange from './isrange';
 import isElement from '../lib/lodash/isElement';
 
-const rectProperties = [ 'top', 'right', 'bottom', 'left', 'width', 'height' ];
-
 /**
  * A helper class representing a `ClientRect` object, e.g. value returned by
  * the native `object.getBoundingClientRect()` method. Provides a set of methods
@@ -54,38 +52,30 @@ export default class Rect {
 			enumerable: false
 		} );
 
-		// Acquires all the rect properties from the passed source.
-		//
-		// @private
-		// @param {ClientRect|module:utils/dom/rect~Rect|Object} source}
-		const setProperties = source => {
-			rectProperties.forEach( p => this[ p ] = source[ p ] );
-		};
-
 		if ( isElement( source ) ) {
-			setProperties( source.getBoundingClientRect() );
+			copyRectProperties( this, source.getBoundingClientRect() );
 		} else if ( isRange( source ) ) {
-			// Use getClientRects() when the range is collapsed
+			// Use getClientRects() when the range is collapsed.
 			// https://github.com/ckeditor/ckeditor5-utils/issues/153
 			if ( source.collapsed ) {
 				const rects = source.getClientRects();
 
 				if ( rects.length ) {
-					setProperties( rects[ 0 ] );
+					copyRectProperties( this, rects[ 0 ] );
 				}
 				// If there's no client rects for the Range, use parent container's bounding
 				// rect instead and adjust rect's width to simulate the actual geometry of such
 				// range.
 				// https://github.com/ckeditor/ckeditor5-utils/issues/153
 				else {
-					setProperties( source.startContainer.getBoundingClientRect() );
+					copyRectProperties( this, source.startContainer.getBoundingClientRect() );
 					this.width = 0;
 				}
 			} else {
-				setProperties( source.getBoundingClientRect() );
+				copyRectProperties( this, source.getBoundingClientRect() );
 			}
 		} else {
-			setProperties( source );
+			copyRectProperties( this, source );
 		}
 
 		/**
@@ -277,5 +267,18 @@ export default class Rect {
 			width: innerWidth,
 			height: innerHeight
 		} );
+	}
+}
+
+const rectProperties = [ 'top', 'right', 'bottom', 'left', 'width', 'height' ];
+
+// Acquires all the rect properties from the passed source.
+//
+// @private
+// @param {module:utils/dom/rect~Rect} rect
+// @param {ClientRect|module:utils/dom/rect~Rect|Object} source
+function copyRectProperties( rect, source ) {
+	for ( const p of rectProperties ) {
+		rect[ p ] = source[ p ];
 	}
 }

--- a/tests/dom/rect.js
+++ b/tests/dom/rect.js
@@ -41,12 +41,39 @@ describe( 'Rect', () => {
 			assertRect( new Rect( element ), geometry );
 		} );
 
-		it( 'should accept Range', () => {
+		it( 'should accept Range (non–collapsed)', () => {
 			const range = document.createRange();
 
+			range.selectNode( document.body );
 			testUtils.sinon.stub( range, 'getBoundingClientRect' ).returns( geometry );
 
 			assertRect( new Rect( range ), geometry );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5-utils/issues/153
+		it( 'should accept Range (collapsed)', () => {
+			const range = document.createRange();
+
+			range.collapse();
+			testUtils.sinon.stub( range, 'getClientRects' ).returns( [ geometry ] );
+
+			assertRect( new Rect( range ), geometry );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5-utils/issues/153
+		it( 'should accept Range (collapsed, no Range rects available)', () => {
+			const range = document.createRange();
+			const element = document.createElement( 'div' );
+
+			range.setStart( element, 0 );
+			range.collapse();
+			testUtils.sinon.stub( range, 'getClientRects' ).returns( [] );
+			testUtils.sinon.stub( element, 'getBoundingClientRect' ).returns( geometry );
+
+			const expectedGeometry = Object.assign( {}, geometry );
+			expectedGeometry.width = 0;
+
+			assertRect( new Rect( range ), expectedGeometry );
 		} );
 
 		it( 'should accept Rect', () => {
@@ -481,6 +508,7 @@ describe( 'Rect', () => {
 
 		it( 'should return the visible rect (Range), partially cropped', () => {
 			range.setStart( ancestorA, 0 );
+			range.setEnd( ancestorA, 1 );
 
 			testUtils.sinon.stub( range, 'getBoundingClientRect' ).returns( {
 				top: 0,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Rect utility should work for collapsed DOM Ranges. Closes #153.