### PR TITLE
t/157: getOptimalPosition should accept a target defined as a function

### DIFF
--- a/src/dom/position.js
+++ b/src/dom/position.js
@@ -76,6 +76,12 @@ import getPositionedAncestor from './getpositionedancestor';
  * @returns {module:utils/dom/position~Position}
  */
 export function getOptimalPosition( { element, target, positions, limiter, fitInViewport } ) {
+	// If the {@link module:utils/dom/position~Options#target} is a function, use what it returns.
+	// https://github.com/ckeditor/ckeditor5-utils/issues/157
+	if ( typeof target == 'function' ) {
+		target = target();
+	}
+
 	const positionedElementAncestor = getPositionedAncestor( element.parentElement );
 	const elementRect = new Rect( element );
 	const targetRect = new Rect( target );
@@ -255,7 +261,7 @@ function getAbsoluteRectCoordinates( { left, top } ) {
 /**
  * Target with respect to which the `element` is to be positioned.
  *
- * @member {HTMLElement|Range|ClientRect} #target
+ * @member {HTMLElement|Range|ClientRect|Function} #target
  */
 
 /**

--- a/tests/dom/position.js
+++ b/tests/dom/position.js
@@ -18,6 +18,20 @@ describe( 'getOptimalPosition()', () => {
 		} );
 	} );
 
+	it( 'should work when the target is a Function', () => {
+		setElementTargetPlayground();
+
+		assertPosition( {
+			element,
+			target: () => target,
+			positions: [ attachLeft ]
+		}, {
+			top: 100,
+			left: 80,
+			name: 'left'
+		} );
+	} );
+
 	describe( 'for single position', () => {
 		beforeEach( setElementTargetPlayground );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `getOptimalPosition` utility should accept the target option defined as a function. Closes #157.