### PR TITLE
t/159: FocusTracker should remain in sync when multiple 'blur' events are followed by the 'focus'

### DIFF
--- a/src/focustracker.js
+++ b/src/focustracker.js
@@ -115,6 +115,8 @@ export default class FocusTracker {
 	 * @fires blur
 	 */
 	_blur() {
+		clearTimeout( this._nextEventLoopTimeout );
+
 		this._nextEventLoopTimeout = setTimeout( () => {
 			this.focusedElement = null;
 			this.isFocused = false;

--- a/tests/focustracker.js
+++ b/tests/focustracker.js
@@ -115,6 +115,19 @@ describe( 'FocusTracker', () => {
 				expect( focusTracker.isFocused ).to.true;
 				expect( changeSpy.notCalled ).to.true;
 			} );
+
+			// https://github.com/ckeditor/ckeditor5-utils/issues/159
+			it( 'should keep `isFocused` synced when multiple blur events are followed by the focus', () => {
+				focusTracker.add( container );
+				focusTracker.isFocused = true;
+
+				container.dispatchEvent( new Event( 'blur' ) );
+				containerFirstInput.dispatchEvent( new Event( 'blur' ) );
+				containerSecondInput.dispatchEvent( new Event( 'focus' ) );
+				testUtils.sinon.clock.tick( 0 );
+
+				expect( focusTracker.isFocused ).to.be.true;
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: FocusTracker should remain in sync when multiple 'blur' events are followed by the 'focus'. Closes #159.