### PR TITLE
t/169: Added support for 'space' key code in parseKeystroke() helper

### DIFF
--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -116,6 +116,7 @@ function generateKnownKeyCodes() {
 		backspace: 8,
 		delete: 46,
 		enter: 13,
+		space: 32,
 		esc: 27,
 		tab: 9,
 

--- a/tests/keyboard.js
+++ b/tests/keyboard.js
@@ -29,7 +29,7 @@ describe( 'Keyboard', () => {
 			expect( keyCodes ).to.include.keys(
 				'ctrl', 'cmd', 'shift', 'alt',
 				'arrowleft', 'arrowup', 'arrowright', 'arrowdown',
-				'backspace', 'delete', 'enter', 'esc', 'tab',
+				'backspace', 'delete', 'enter', 'space', 'esc', 'tab',
 				'f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10', 'f11', 'f12'
 			);
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added support for 'space' key code in parseKeystroke() helper. Closes #169.