### PR TITLE
Remove "anySymbol in smth" statements.

### DIFF
--- a/src/observablemixin.js
+++ b/src/observablemixin.js
@@ -197,7 +197,7 @@ const ObservableMixin = {
 	 */
 	unbind( ...unbindAttrs ) {
 		// Nothing to do here if not inited yet.
-		if ( !( attributesSymbol in this ) ) {
+		if ( !this[attributesSymbol] ) {
 			return;
 		}
 
@@ -356,7 +356,7 @@ export default ObservableMixin;
 // @param {module:utils/observablemixin~ObservableMixin} observable
 function initObservable( observable ) {
 	// Do nothing if already inited.
-	if ( attributesSymbol in observable ) {
+	if ( observable[attributesSymbol] ) {
 		return;
 	}
 

--- a/src/observablemixin.js
+++ b/src/observablemixin.js
@@ -197,7 +197,7 @@ const ObservableMixin = {
 	 */
 	unbind( ...unbindAttrs ) {
 		// Nothing to do here if not inited yet.
-		if ( !this[attributesSymbol] ) {
+		if ( !this[ attributesSymbol ] ) {
 			return;
 		}
 
@@ -356,7 +356,7 @@ export default ObservableMixin;
 // @param {module:utils/observablemixin~ObservableMixin} observable
 function initObservable( observable ) {
 	// Do nothing if already inited.
-	if ( observable[attributesSymbol] ) {
+	if ( observable[ attributesSymbol ] ) {
 		return;
 	}
 


### PR DESCRIPTION
Remove "anySymbol in smth" statements. They are incompatible with core-js polyfill.
In fact that's a core-js implementation (Symbol('any string') in AnyObject === true) problem, but it is much more difficult to fix babel-polyfill rather then two lines of code.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Message. Closes #000.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
