### PR TITLE
t/178: A warning should show up when a Rect instance is for an HTML element or a DOM range not belonging to a rendered DOM tree

### DIFF
--- a/tests/dom/rect.js
+++ b/tests/dom/rect.js
@@ -7,6 +7,7 @@
 
 import global from '../../src/dom/global';
 import Rect from '../../src/dom/rect';
+import log from '../../src/log';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 testUtils.createSinonSandbox();
@@ -138,6 +139,31 @@ describe( 'Rect', () => {
 			rect.width = 200;
 
 			assertRect( geometry, sourceGeometry );
+		} );
+
+		it( 'should warn if the source does not belong to rendered DOM tree (HTML element)', () => {
+			const element = document.createElement( 'div' );
+
+			testUtils.sinon.stub( log, 'warn' );
+			testUtils.sinon.stub( element, 'getBoundingClientRect' ).returns( geometry );
+
+			const rect = new Rect( element );
+			sinon.assert.calledOnce( log.warn );
+			sinon.assert.calledWithExactly( log.warn, sinon.match( /^rect-source-not-in-dom/ ), { source: element } );
+			assertRect( rect, geometry );
+		} );
+
+		it( 'should warn if the source does not belong to rendered DOM tree (DOM Range)', () => {
+			const range = document.createRange();
+
+			testUtils.sinon.stub( log, 'warn' );
+			range.collapse();
+			testUtils.sinon.stub( range, 'getClientRects' ).returns( [ geometry ] );
+
+			const rect = new Rect( range );
+			sinon.assert.calledOnce( log.warn );
+			sinon.assert.calledWithExactly( log.warn, sinon.match( /^rect-source-not-in-dom/ ), { source: range } );
+			assertRect( rect, geometry );
 		} );
 	} );
 

--- a/tests/dom/rect.js
+++ b/tests/dom/rect.js
@@ -24,6 +24,8 @@ describe( 'Rect', () => {
 			width: 20,
 			height: 20
 		};
+
+		testUtils.sinon.stub( log, 'warn' );
 	} );
 
 	describe( 'constructor()', () => {
@@ -144,7 +146,6 @@ describe( 'Rect', () => {
 		it( 'should warn if the source does not belong to rendered DOM tree (HTML element)', () => {
 			const element = document.createElement( 'div' );
 
-			testUtils.sinon.stub( log, 'warn' );
 			testUtils.sinon.stub( element, 'getBoundingClientRect' ).returns( geometry );
 
 			const rect = new Rect( element );
@@ -156,7 +157,6 @@ describe( 'Rect', () => {
 		it( 'should warn if the source does not belong to rendered DOM tree (DOM Range)', () => {
 			const range = document.createRange();
 
-			testUtils.sinon.stub( log, 'warn' );
 			range.collapse();
 			testUtils.sinon.stub( range, 'getClientRects' ).returns( [ geometry ] );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: A warning should show up when a Rect instance is for an HTML element or a DOM range not belonging to a rendered DOM tree. Closes #178.

----

Branches in other repositories to silence the warnings:

* https://github.com/ckeditor/ckeditor5-editor-inline/compare/t/ckeditor5-utils/178
* https://github.com/ckeditor/ckeditor5-ui/compare/t/ckeditor5-utils/178
* https://github.com/ckeditor/ckeditor5-engine/compare/t/ckeditor5-utils/178