### PR TITLE
T/185: CKEditorError and logger will contain a link to documentation

### DIFF
--- a/src/ckeditorerror.js
+++ b/src/ckeditorerror.js
@@ -8,6 +8,11 @@
  */
 
 /**
+ * URL to the documentation with error codes.
+ */
+export const DOCUMENTATION_URL = 'https://ckeditor5.github.io/docs/nightly/ckeditor5/latest/framework/guides/error-codes.html';
+
+/**
  * The CKEditor error class.
  *
  * All errors will be shortened during the minification process in order to reduce the code size.
@@ -31,6 +36,8 @@ export default class CKEditorError extends Error {
 	 * data object will also be later available under the {@link #data} property.
 	 */
 	constructor( message, data ) {
+		message = attachLinkToDocumentation( message );
+
 		if ( data ) {
 			message += ' ' + JSON.stringify( data );
 		}
@@ -59,4 +66,20 @@ export default class CKEditorError extends Error {
 	static isCKEditorError( error ) {
 		return error instanceof CKEditorError;
 	}
+}
+
+/**
+ * Attaches link to the documentation at the end of the error message.
+ *
+ * @param {String} message Message to be logged.
+ * @returns {String}
+ */
+export function attachLinkToDocumentation( message ) {
+	const matchedErrorName = message.match( /^([^:]+):/ );
+
+	if ( !matchedErrorName ) {
+		return message;
+	}
+
+	return message + ` Read more: ${ DOCUMENTATION_URL }#${ matchedErrorName[ 1 ] }.\n`;
 }

--- a/src/log.js
+++ b/src/log.js
@@ -9,6 +9,8 @@
  * @module utils/log
  */
 
+const DOCUMENTATION_URL = 'https://ckeditor5.github.io/docs/nightly/ckeditor5/latest/framework/guides/error-codes.html';
+
 /**
  * The logging module.
  *
@@ -53,7 +55,7 @@ const log = {
 	 * @param {Object} [data] Additional data describing the error.
 	 */
 	error( message, data ) {
-		console.error( message, data );
+		console.error( attachLinkToDocumentation( message ), data );
 	},
 
 	/**
@@ -67,8 +69,22 @@ const log = {
 	 * @param {Object} [data] Additional data describing the warning.
 	 */
 	warn( message, data ) {
-		console.warn( message, data );
+		console.warn( attachLinkToDocumentation( message ), data );
 	}
 };
 
 export default log;
+
+// Attaches link to the documentation at the end of the log message.
+//
+// @param {String} message
+// @returns {String}
+function attachLinkToDocumentation( message ) {
+	const matchedErrorName = message.match( /^([^:]+):/ );
+
+	if ( !matchedErrorName ) {
+		return message;
+	}
+
+	return message + ` Read more: ${ DOCUMENTATION_URL }#${ matchedErrorName[ 1 ] }.\n`;
+}

--- a/src/log.js
+++ b/src/log.js
@@ -9,7 +9,7 @@
  * @module utils/log
  */
 
-const DOCUMENTATION_URL = 'https://ckeditor5.github.io/docs/nightly/ckeditor5/latest/framework/guides/error-codes.html';
+import { attachLinkToDocumentation } from './ckeditorerror';
 
 /**
  * The logging module.
@@ -74,17 +74,3 @@ const log = {
 };
 
 export default log;
-
-// Attaches link to the documentation at the end of the log message.
-//
-// @param {String} message
-// @returns {String}
-function attachLinkToDocumentation( message ) {
-	const matchedErrorName = message.match( /^([^:]+):/ );
-
-	if ( !matchedErrorName ) {
-		return message;
-	}
-
-	return message + ` Read more: ${ DOCUMENTATION_URL }#${ matchedErrorName[ 1 ] }.\n`;
-}

--- a/tests/ckeditorerror.js
+++ b/tests/ckeditorerror.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import CKEditorError from '../src/ckeditorerror';
+import { default as CKEditorError, DOCUMENTATION_URL } from '../src/ckeditorerror';
 
 describe( 'CKEditorError', () => {
 	it( 'inherits from Error', () => {
@@ -50,6 +50,25 @@ describe( 'CKEditorError', () => {
 
 		expect( error ).to.have.property( 'message', 'foo {"bar":"a","bom":{"x":1},"bim":10}' );
 		expect( error ).to.have.property( 'data', data );
+	} );
+
+	it( 'contains a link which leads to the documentation', () => {
+		const error = new CKEditorError( 'model-schema-no-item: Specified item cannot be found.' );
+
+		const errorMessage = 'model-schema-no-item: Specified item cannot be found. ' +
+			`Read more: ${ DOCUMENTATION_URL }#model-schema-no-item.\n`;
+
+		expect( error ).to.have.property( 'message', errorMessage );
+	} );
+
+	it( 'link to documentation is added before the additional data message', () => {
+		const error = new CKEditorError( 'model-schema-no-item: Specified item cannot be found.', { foo: 1, bar: 2 } );
+
+		const errorMessage = 'model-schema-no-item: Specified item cannot be found. ' +
+			`Read more: ${ DOCUMENTATION_URL }#model-schema-no-item.\n ` +
+			'{"foo":1,"bar":2}';
+
+		expect( error ).to.have.property( 'message', errorMessage );
 	} );
 
 	describe( 'isCKEditorError', () => {

--- a/tests/log.js
+++ b/tests/log.js
@@ -6,6 +6,7 @@
 /* globals console */
 
 import log from '../src/log';
+import { DOCUMENTATION_URL } from '../src/ckeditorerror';
 
 describe( 'log', () => {
 	let spy;
@@ -36,10 +37,8 @@ describe( 'log', () => {
 
 			log.warn( 'model-schema-no-item: Specified item cannot be found.' );
 
-			/* eslint-disable max-len */
 			const logMessage = 'model-schema-no-item: Specified item cannot be found. ' +
-				'Read more: https://ckeditor5.github.io/docs/nightly/ckeditor5/latest/framework/guides/error-codes.html#model-schema-no-item.\n';
-			/* eslint-enable max-len */
+				`Read more: ${ DOCUMENTATION_URL }#model-schema-no-item.\n`;
 
 			sinon.assert.calledOnce( spy );
 			sinon.assert.calledWith( spy, logMessage );
@@ -66,10 +65,8 @@ describe( 'log', () => {
 
 			log.error( 'model-schema-no-item: Specified item cannot be found.' );
 
-			/* eslint-disable max-len */
 			const logMessage = 'model-schema-no-item: Specified item cannot be found. ' +
-				'Read more: https://ckeditor5.github.io/docs/nightly/ckeditor5/latest/framework/guides/error-codes.html#model-schema-no-item.\n';
-			/* eslint-enable max-len */
+				`Read more: ${ DOCUMENTATION_URL }#model-schema-no-item.\n`;
 
 			sinon.assert.calledOnce( spy );
 			sinon.assert.calledWith( spy, logMessage );

--- a/tests/log.js
+++ b/tests/log.js
@@ -18,7 +18,7 @@ describe( 'log', () => {
 
 	describe( 'warn()', () => {
 		it( 'logs the message to the console using console.warn()', () => {
-			const spy = sinon.stub( console, 'warn' );
+			spy = sinon.stub( console, 'warn' );
 			const data = { bar: 1 };
 
 			log.warn( 'foo', data );
@@ -30,11 +30,25 @@ describe( 'log', () => {
 			sinon.assert.calledTwice( spy );
 			sinon.assert.calledWith( spy, 'bar' );
 		} );
+
+		it( 'contains a link which leads to the documentation', () => {
+			spy = sinon.stub( console, 'warn' );
+
+			log.warn( 'model-schema-no-item: Specified item cannot be found.' );
+
+			/* eslint-disable max-len */
+			const logMessage = 'model-schema-no-item: Specified item cannot be found. ' +
+				'Read more: https://ckeditor5.github.io/docs/nightly/ckeditor5/latest/framework/guides/error-codes.html#model-schema-no-item.\n';
+			/* eslint-enable max-len */
+
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledWith( spy, logMessage );
+		} );
 	} );
 
 	describe( 'error()', () => {
 		it( 'logs the message to the console using console.error()', () => {
-			const spy = sinon.stub( console, 'error' );
+			spy = sinon.stub( console, 'error' );
 			const data = { bar: 1 };
 
 			log.error( 'foo', data );
@@ -45,6 +59,20 @@ describe( 'log', () => {
 			log.error( 'bar' );
 			sinon.assert.calledTwice( spy );
 			sinon.assert.calledWith( spy, 'bar' );
+		} );
+
+		it( 'contains a link which leads to the documentation', () => {
+			spy = sinon.stub( console, 'error' );
+
+			log.error( 'model-schema-no-item: Specified item cannot be found.' );
+
+			/* eslint-disable max-len */
+			const logMessage = 'model-schema-no-item: Specified item cannot be found. ' +
+				'Read more: https://ckeditor5.github.io/docs/nightly/ckeditor5/latest/framework/guides/error-codes.html#model-schema-no-item.\n';
+			/* eslint-enable max-len */
+
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledWith( spy, logMessage );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `CKEditorError.message`, `log.error()` and `log.warn()` will contain a link to the documentation. Closes #185.
