### PR TITLE
Other: Remove context options form EmitterMixin.

### DIFF
--- a/src/dom/emittermixin.js
+++ b/src/dom/emittermixin.js
@@ -46,7 +46,6 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 	 * @param {module:utils/priorities~PriorityString|Number} [options.priority='normal'] The priority of this event callback. The higher
 	 * the priority value the sooner the callback will be fired. Events having the same priority are called in the
 	 * order they were added.
-	 * @param {Object} [options.context] The object that represents `this` in the callback. Defaults to the object firing the event.
 	 * @param {Boolean} [options.useCapture=false] Indicates that events of this type will be dispatched to the registered
 	 * listener before being dispatched to any EventTarget beneath it in the DOM tree.
 	 *
@@ -179,7 +178,6 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 	 * @param {module:utils/priorities~PriorityString|Number} [options.priority='normal'] The priority of this event callback. The higher
 	 * the priority value the sooner the callback will be fired. Events having the same priority are called in the
 	 * order they were added.
-	 * @param {Object} [options.context] The object that represents `this` in the callback. Defaults to the object firing the event.
 	 * @param {Boolean} [options.useCapture=false] Indicates that events of this type will be dispatched to the registered
 	 * listener before being dispatched to any EventTarget beneath it in the DOM tree.
 	 *
@@ -214,14 +212,12 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 	 *
 	 * @param {String} event The name of the event.
 	 * @param {Function} callback The function to stop being called.
-	 * @param {Object} [context] The context object to be removed, pared with the given callback. To handle cases where
-	 * the same callback is used several times with different contexts.
 	 *
 	 * @method module:utils/dom/emittermixin~ProxyEmitter#off
 	 */
-	off( event, callback, context ) {
+	off( event, callback ) {
 		// Execute parent class method first.
-		EmitterMixin.off.call( this, event, callback, context );
+		EmitterMixin.off.call( this, event, callback );
 
 		let events;
 

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -25,7 +25,7 @@ const EmitterMixin = {
 	 * Registers a callback function to be executed when an event is fired.
 	 *
 	 * Events can be grouped in namespaces using `:`.
-	 * When namespaced event is fired, it additionaly fires all callbacks for that namespace.
+	 * When namespaced event is fired, it additionally fires all callbacks for that namespace.
 	 *
 	 *		myEmitter.on( 'myGroup', genericCallback );
 	 *		myEmitter.on( 'myGroup:myEvent', specificCallback );
@@ -47,7 +47,6 @@ const EmitterMixin = {
 	 * @param {module:utils/priorities~PriorityString|Number} [options.priority='normal'] The priority of this event callback. The higher
 	 * the priority value the sooner the callback will be fired. Events having the same priority are called in the
 	 * order they were added.
-	 * @param {Object} [options.context] The object that represents `this` in the callback. Defaults to the object firing the event.
 	 */
 	on( event, callback, options = {} ) {
 		createEventNamespace( this, event );
@@ -56,7 +55,6 @@ const EmitterMixin = {
 
 		callback = {
 			callback,
-			context: options.context || this,
 			priority
 		};
 
@@ -92,7 +90,6 @@ const EmitterMixin = {
 	 * @param {module:utils/priorities~PriorityString|Number} [options.priority='normal'] The priority of this event callback. The higher
 	 * the priority value the sooner the callback will be fired. Events having the same priority are called in the
 	 * order they were added.
-	 * @param {Object} [options.context] The object that represents `this` in the callback. Defaults to the object firing the event.
 	 */
 	once( event, callback, options ) {
 		const onceCallback = function( event, ...args ) {
@@ -113,20 +110,16 @@ const EmitterMixin = {
 	 * @method #off
 	 * @param {String} event The name of the event.
 	 * @param {Function} callback The function to stop being called.
-	 * @param {Object} [context] The context object to be removed, pared with the given callback. To handle cases where
-	 * the same callback is used several times with different contexts.
 	 */
-	off( event, callback, context ) {
+	off( event, callback ) {
 		const lists = getCallbacksListsForNamespace( this, event );
 
 		for ( const callbacks of lists ) {
 			for ( let i = 0; i < callbacks.length; i++ ) {
 				if ( callbacks[ i ].callback == callback ) {
-					if ( !context || context == callbacks[ i ].context ) {
-						// Remove the callback from the list (fixing the next index).
-						callbacks.splice( i, 1 );
-						i--;
-					}
+					// Remove the callback from the list (fixing the next index).
+					callbacks.splice( i, 1 );
+					i--;
 				}
 			}
 		}
@@ -143,7 +136,6 @@ const EmitterMixin = {
 	 * @param {module:utils/priorities~PriorityString|Number} [options.priority='normal'] The priority of this event callback. The higher
 	 * the priority value the sooner the callback will be fired. Events having the same priority are called in the
 	 * order they were added.
-	 * @param {Object} [options.context] The object that represents `this` in the callback. Defaults to the object firing the event.
 	 */
 	listenTo( emitter, event, callback, options ) {
 		let emitterInfo, eventCallbacks;
@@ -278,14 +270,14 @@ const EmitterMixin = {
 			callbacks = Array.from( callbacks );
 
 			for ( let i = 0; i < callbacks.length; i++ ) {
-				callbacks[ i ].callback.apply( callbacks[ i ].context, callbackArgs );
+				callbacks[ i ].callback.apply( this, callbackArgs );
 
 				// Remove the callback from future requests if off() has been called.
 				if ( eventInfo.off.called ) {
 					// Remove the called mark for the next calls.
 					delete eventInfo.off.called;
 
-					this.off( event, callbacks[ i ].callback, callbacks[ i ].context );
+					this.off( event, callbacks[ i ].callback );
 				}
 
 				// Do not execute next callbacks if stop() was called.

--- a/tests/emittermixin.js
+++ b/tests/emittermixin.js
@@ -60,16 +60,6 @@ describe( 'EmitterMixin', () => {
 			sinon.assert.calledWithExactly( spy2, sinon.match.instanceOf( EventInfo ), 1, 'b', true );
 		} );
 
-		it( 'should pass proper context to callbacks', () => {
-			const spy = sinon.spy();
-
-			emitter.on( 'test', spy );
-
-			emitter.fire( 'test' );
-
-			sinon.assert.calledOn( spy, emitter );
-		} );
-
 		it( 'should fire the right event', () => {
 			const spy1 = sinon.spy();
 			const spy2 = sinon.spy();
@@ -305,16 +295,6 @@ describe( 'EmitterMixin', () => {
 			sinon.assert.calledTwice( spy1 );
 			sinon.assert.calledOnce( spy2 );
 			sinon.assert.calledTwice( spy3 );
-		} );
-
-		it( 'should have proper scope', () => {
-			const spy = sinon.spy();
-
-			emitter.once( 'test', spy );
-
-			emitter.fire( 'test' );
-
-			sinon.assert.calledOn( spy, emitter );
 		} );
 
 		it( 'should have proper arguments', () => {

--- a/tests/emittermixin.js
+++ b/tests/emittermixin.js
@@ -61,22 +61,13 @@ describe( 'EmitterMixin', () => {
 		} );
 
 		it( 'should pass proper context to callbacks', () => {
-			const ctx1 = {};
-			const ctx2 = {};
+			const spy = sinon.spy();
 
-			const spy1 = sinon.spy();
-			const spy2 = sinon.spy();
-			const spy3 = sinon.spy();
-
-			emitter.on( 'test', spy1, { context: ctx1 } );
-			emitter.on( 'test', spy2, { context: ctx2 } );
-			emitter.on( 'test', spy3 );
+			emitter.on( 'test', spy );
 
 			emitter.fire( 'test' );
 
-			sinon.assert.calledOn( spy1, ctx1 );
-			sinon.assert.calledOn( spy2, ctx2 );
-			sinon.assert.calledOn( spy3, emitter );
+			sinon.assert.calledOn( spy, emitter );
 		} );
 
 		it( 'should fire the right event', () => {
@@ -317,18 +308,13 @@ describe( 'EmitterMixin', () => {
 		} );
 
 		it( 'should have proper scope', () => {
-			const ctx = {};
+			const spy = sinon.spy();
 
-			const spy1 = sinon.spy();
-			const spy2 = sinon.spy();
-
-			emitter.once( 'test', spy1, { context: ctx } );
-			emitter.once( 'test', spy2 );
+			emitter.once( 'test', spy );
 
 			emitter.fire( 'test' );
 
-			sinon.assert.calledOn( spy1, ctx );
-			sinon.assert.calledOn( spy2, emitter );
+			sinon.assert.calledOn( spy, emitter );
 		} );
 
 		it( 'should have proper arguments', () => {
@@ -385,27 +371,6 @@ describe( 'EmitterMixin', () => {
 
 			sinon.assert.callCount( spy1, 2 );
 			sinon.assert.callCount( spy2, 4 );
-		} );
-
-		it( 'should remove the callback for given context only', () => {
-			const spy = sinon.spy().named( 1 );
-
-			const ctx1 = { context: 1 };
-			const ctx2 = { context: 2 };
-
-			emitter.on( 'test', spy, { context: ctx1 } );
-			emitter.on( 'test', spy, { context: ctx2 } );
-
-			emitter.fire( 'test' );
-
-			spy.reset();
-
-			emitter.off( 'test', spy, ctx1 );
-
-			emitter.fire( 'test' );
-
-			sinon.assert.calledOnce( spy );
-			sinon.assert.calledOn( spy, ctx2 );
 		} );
 
 		it( 'should properly remove callbacks for namespaced events', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove context options form `EmitterMixin` methods: `on`, `once`, `listenTo` and `off`. Closes #77.

BREAKING CHANGE: `EmitterMixin.on` no longer accepts `context` option. Callbacks are now called in `EmitterMixin` instance context. See #77.
BREAKING CHANGE: `EmitterMixin.once` no longer accepts `context` parameter.  Callbacks are now called in `EmitterMixin` instance context. See #77.
BREAKING CHANGE: `EmitterMixin.listenTo` no longer accepts `context` option.   Callbacks are now called in `EmitterMixin`context of emitter instance passed to `listenTo`. See #77.
BREAKING CHANGE: `EmitterMixin.off` no longer accepts `context` option. See #77.

---

### Additional information

*  As usual please give me feedback on this PR message also. I was struggling with either this or merging `BREAKING CHANGE`'s to one sentence (similar to commit message).
* I didn't catch any calls with `{ context: foo }` in code other then those in tests.
