### PR TITLE
T/144: Refactor EmitterMixin methods.

### DIFF
--- a/src/dom/emittermixin.js
+++ b/src/dom/emittermixin.js
@@ -174,13 +174,12 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 	 * It attaches a native DOM listener to the DOM Node. When fired,
 	 * a corresponding Emitter event will also fire with DOM Event object as an argument.
 	 *
+	 * @method module:utils/dom/emittermixin~ProxyEmitter#on
 	 * @param {String} event The name of the event.
 	 * @param {Function} callback The function to be called on event.
 	 * @param {Object} [options={}] Additional options.
 	 * @param {Boolean} [options.useCapture=false] Indicates that events of this type will be dispatched to the registered
 	 * listener before being dispatched to any EventTarget beneath it in the DOM tree.
-	 *
-	 * @method module:utils/dom/emittermixin~ProxyEmitter#on
 	 */
 	attach( event, callback, options = {} ) {
 		// If the DOM Listener for given event already exist it is pointless
@@ -206,9 +205,8 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 	/**
 	 * Stops executing the callback on the given event.
 	 *
+	 * @method module:utils/dom/emittermixin~ProxyEmitter#detach
 	 * @param {String} event The name of the event.
-	 *
-	 * @method module:utils/dom/emittermixin~ProxyEmitter#off
 	 */
 	detach( event ) {
 		let events;

--- a/src/dom/emittermixin.js
+++ b/src/dom/emittermixin.js
@@ -51,7 +51,7 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 	 *
 	 * @method module:utils/dom/emittermixin~EmitterMixin#listenTo
 	 */
-	listenTo( emitter, event, callback, options = {} ) {
+	listenTo( emitter, event, callback, options ) {
 		// Check if emitter is an instance of DOM Node. If so, replace the argument with
 		// corresponding ProxyEmitter (or create one if not existing).
 		if ( isDomNode( emitter ) ) {

--- a/src/dom/emittermixin.js
+++ b/src/dom/emittermixin.js
@@ -51,19 +51,19 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 	 *
 	 * @method module:utils/dom/emittermixin~EmitterMixin#listenTo
 	 */
-	listenTo( emitter, event, callback, options ) {
+	listenTo( emitter, ...rest ) {
 		// Check if emitter is an instance of DOM Node. If so, replace the argument with
 		// corresponding ProxyEmitter (or create one if not existing).
 		if ( isDomNode( emitter ) ) {
 			const proxy = this._getProxyEmitter( emitter ) || new ProxyEmitter( emitter );
 
-			proxy.attach( event, callback, options );
+			proxy.attach( ...rest );
 
 			emitter = proxy;
 		}
 
 		// Execute parent class method with Emitter (or ProxyEmitter) instance.
-		EmitterMixin.listenTo.call( this, emitter, event, callback, options );
+		EmitterMixin.listenTo.call( this, emitter, ...rest );
 	},
 
 	/**
@@ -100,7 +100,7 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 		EmitterMixin.stopListening.call( this, emitter, event, callback );
 
 		if ( emitter instanceof ProxyEmitter ) {
-			emitter.detach( event, callback );
+			emitter.detach( event );
 		}
 	},
 

--- a/src/dom/emittermixin.js
+++ b/src/dom/emittermixin.js
@@ -51,17 +51,17 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 	 *
 	 * @method module:utils/dom/emittermixin~EmitterMixin#listenTo
 	 */
-	listenTo( ...args ) {
-		const emitter = args[ 0 ];
-
+	listenTo( emitter, event, callback, options = {} ) {
 		// Check if emitter is an instance of DOM Node. If so, replace the argument with
 		// corresponding ProxyEmitter (or create one if not existing).
 		if ( isDomNode( emitter ) ) {
-			args[ 0 ] = this._getProxyEmitter( emitter ) || new ProxyEmitter( emitter );
+			emitter = this._getProxyEmitter( emitter ) || new ProxyEmitter( emitter );
+
+			emitter.registerEvent( event, callback, options );
 		}
 
 		// Execute parent class method with Emitter (or ProxyEmitter) instance.
-		EmitterMixin.listenTo.apply( this, args );
+		EmitterMixin.listenTo.call( this, emitter, event, callback, options );
 	},
 
 	/**
@@ -81,9 +81,7 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 	 *
 	 * @method module:utils/dom/emittermixin~EmitterMixin#stopListening
 	 */
-	stopListening( ...args ) {
-		const emitter = args[ 0 ];
-
+	stopListening( emitter, event, callback ) {
 		// Check if emitter is an instance of DOM Node. If so, replace the argument with corresponding ProxyEmitter.
 		if ( isDomNode( emitter ) ) {
 			const proxy = this._getProxyEmitter( emitter );
@@ -93,11 +91,11 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 				return;
 			}
 
-			args[ 0 ] = proxy;
+			emitter = proxy;
 		}
 
 		// Execute parent class method with Emitter (or ProxyEmitter) instance.
-		EmitterMixin.stopListening.apply( this, args );
+		EmitterMixin.stopListening.call( this, emitter, event, callback );
 	},
 
 	/**
@@ -183,10 +181,7 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 	 *
 	 * @method module:utils/dom/emittermixin~ProxyEmitter#on
 	 */
-	on( event, callback, options = {} ) {
-		// Execute parent class method first.
-		EmitterMixin.on.call( this, event, callback, options );
-
+	registerEvent( event, callback, options = {} ) {
 		// If the DOM Listener for given event already exist it is pointless
 		// to attach another one.
 		if ( this._domListeners && this._domListeners[ event ] ) {

--- a/src/dom/emittermixin.js
+++ b/src/dom/emittermixin.js
@@ -174,7 +174,7 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 	 * It attaches a native DOM listener to the DOM Node. When fired,
 	 * a corresponding Emitter event will also fire with DOM Event object as an argument.
 	 *
-	 * @method module:utils/dom/emittermixin~ProxyEmitter#on
+	 * @method module:utils/dom/emittermixin~ProxyEmitter#attach
 	 * @param {String} event The name of the event.
 	 * @param {Function} callback The function to be called on event.
 	 * @param {Object} [options={}] Additional options.
@@ -213,7 +213,7 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 
 		// Remove native DOM listeners which are orphans. If no callbacks
 		// are awaiting given event, detach native DOM listener from DOM Node.
-		// See: {@link on}.
+		// See: {@link attach}.
 
 		if ( this._domListeners[ event ] && ( !( events = this._events[ event ] ) || !events.callbacks.length ) ) {
 			this._domListeners[ event ].removeListener();
@@ -238,7 +238,7 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 
 		// Supply the DOM listener callback with a function that will help
 		// detach it from the DOM Node, when it is no longer necessary.
-		// See: {@link off}.
+		// See: {@link detach}.
 		domListener.removeListener = () => {
 			this._domNode.removeEventListener( event, domListener, useCapture );
 			delete this._domListeners[ event ];

--- a/src/dom/emittermixin.js
+++ b/src/dom/emittermixin.js
@@ -39,6 +39,7 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 	 * Registers a callback function to be executed when an event is fired in a specific Emitter or DOM Node.
 	 * It is backwards compatible with {@link module:utils/emittermixin~EmitterMixin#listenTo}.
 	 *
+	 * @method module:utils/dom/emittermixin~EmitterMixin#listenTo
 	 * @param {module:utils/emittermixin~Emitter|Node} emitter The object that fires the event.
 	 * @param {String} event The name of the event.
 	 * @param {Function} callback The function to be called on event.
@@ -48,8 +49,6 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 	 * order they were added.
 	 * @param {Boolean} [options.useCapture=false] Indicates that events of this type will be dispatched to the registered
 	 * listener before being dispatched to any EventTarget beneath it in the DOM tree.
-	 *
-	 * @method module:utils/dom/emittermixin~EmitterMixin#listenTo
 	 */
 	listenTo( emitter, ...rest ) {
 		// Check if emitter is an instance of DOM Node. If so, replace the argument with
@@ -75,13 +74,12 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 	 * * To stop listening to all events fired by a specific object.
 	 * * To stop listening to all events fired by all object.
 	 *
+	 * @method module:utils/dom/emittermixin~EmitterMixin#stopListening
 	 * @param {module:utils/emittermixin~Emitter|Node} [emitter] The object to stop listening to. If omitted, stops it for all objects.
 	 * @param {String} [event] (Requires the `emitter`) The name of the event to stop listening to. If omitted, stops it
 	 * for all events from `emitter`.
 	 * @param {Function} [callback] (Requires the `event`) The function to be removed from the call list for the given
 	 * `event`.
-	 *
-	 * @method module:utils/dom/emittermixin~EmitterMixin#stopListening
 	 */
 	stopListening( emitter, event, callback ) {
 		// Check if emitter is an instance of DOM Node. If so, replace the argument with corresponding ProxyEmitter.
@@ -225,13 +223,11 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 	},
 
 	/**
-	 * Create a native DOM listener callback. When the native DOM event
+	 * Creates a native DOM listener callback. When the native DOM event
 	 * is fired it will fire corresponding event on this ProxyEmitter.
 	 * Note: A native DOM Event is passed as an argument.
 	 *
 	 * @private
-	 * @param {String} event
-	 *
 	 * @method module:utils/dom/emittermixin~ProxyEmitter#_createDomListener
 	 * @param {String} event The name of the event.
 	 * @param {Boolean} useCapture Indicates whether the listener was created for capturing event.

--- a/src/dom/emittermixin.js
+++ b/src/dom/emittermixin.js
@@ -263,15 +263,6 @@ function getNodeUID( node ) {
 	return node[ 'data-ck-expando' ] || ( node[ 'data-ck-expando' ] = uid() );
 }
 
-// Checks (naively) if given node is native DOM Node.
-//
-// @private
-// @param {Node} node
-// @return {Boolean} True when native DOM Node.
-function isDomNode( node ) {
-	return !!node && isNative( node.addEventListener );
-}
-
 /**
  * Interface representing classes which mix in {@link module:utils/dom/emittermixin~EmitterMixin}.
  *

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -504,14 +504,8 @@ function createEventNamespace( source, eventName ) {
 // Gets an array containing callbacks list for a given event and it's more specific events.
 // I.e. if given event is foo:bar and there is also foo:bar:abc event registered, this will
 // return callback list of foo:bar and foo:bar:abc (but not foo).
-// Returns empty array if given event has not been yet registered.
 function getCallbacksListsForNamespace( source, eventName ) {
 	const eventNode = getEvents( source )[ eventName ];
-
-	/* istanbul ignore if: this check make sense but in code it does not occur. */
-	if ( !eventNode ) {
-		return [];
-	}
 
 	let callbacksLists = [ eventNode.callbacks ];
 

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2017, CKSource Frederico Knabben. All rights reserved.
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md.
  */
 

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -507,6 +507,10 @@ function createEventNamespace( source, eventName ) {
 function getCallbacksListsForNamespace( source, eventName ) {
 	const eventNode = getEvents( source )[ eventName ];
 
+	if ( !eventNode ) {
+		return [];
+	}
+
 	let callbacksLists = [ eventNode.callbacks ];
 
 	for ( let i = 0; i < eventNode.childEvents.length; i++ ) {

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -505,6 +505,7 @@ function createEventNamespace( source, eventName ) {
 function getCallbacksListsForNamespace( source, eventName ) {
 	const eventNode = getEvents( source )[ eventName ];
 
+	/* istanbul ignore if: this check make sense but in code it does not occur. */
 	if ( !eventNode ) {
 		return [];
 	}

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2017, CKSource -insteadico Knabben. All rights reserved.
+ * @license Copyright (c) 2003-2017, CKSource Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md.
  */
 

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -203,12 +203,12 @@ const EmitterMixin = {
 
 		// All params provided. off() that single callback.
 		if ( callback ) {
-			offCallback( emitter, event, callback );
+			removeCallback( emitter, event, callback );
 		}
 		// Only `emitter` and `event` provided. off() all callbacks for that event.
 		else if ( eventCallbacks ) {
 			while ( ( callback = eventCallbacks.pop() ) ) {
-				offCallback( emitter, event, callback );
+				removeCallback( emitter, event, callback );
 			}
 
 			delete emitterInfo.callbacks[ event ];
@@ -270,7 +270,7 @@ const EmitterMixin = {
 					// Remove the called mark for the next calls.
 					delete eventInfo.off.called;
 
-					offCallback( this, event, callbacks[ i ].callback );
+					removeCallback( this, event, callbacks[ i ].callback );
 				}
 
 				// Do not execute next callbacks if stop() was called.
@@ -568,7 +568,7 @@ function fireDelegatedEvents( destinations, eventInfo, fireArgs ) {
 // @param {module:utils/emittermixin~Emitter} emitter
 // @param {String} event
 // @param {Function} callback
-function offCallback( emitter, event, callback ) {
+function removeCallback( emitter, event, callback ) {
 	const lists = getCallbacksListsForNamespace( emitter, event );
 
 	for ( const callbacks of lists ) {

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -242,7 +242,7 @@ const EmitterMixin = {
 	 * @param {String|module:utils/eventinfo~EventInfo} eventOrInfo The name of the event or `EventInfo` object if event is delegated.
 	 * @param {...*} [args] Additional arguments to be passed to the callbacks.
 	 * @returns {*} By default the method returns `undefined`. However, the return value can be changed by listeners
-	 * through modification of the {@link module:utils/eventinfo~EventInfo#return}'s value (the event info
+	 * through modification of the {@link module:utils/eventinfo~EventInfo#return `evt.return`}'s property (the event info
 	 * is the first param of every callback).
 	 */
 	fire( eventOrInfo, ...args ) {

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -23,23 +23,9 @@ const _emitterId = Symbol( 'emitterId' );
 const EmitterMixin = {
 	/**
 	 * Registers a callback function to be executed when an event is fired.
-	 * Shorthand for {@link #listenTo this.listenTo( this, event, callback, options) }.
 	 *
-	 * Events can be grouped in namespaces using `:`.
-	 * When namespaced event is fired, it additionally fires all callbacks for that namespace.
-	 *
-	 *		myEmitter.on( 'myGroup', genericCallback );
-	 *		myEmitter.on( 'myGroup:myEvent', specificCallback );
-	 *
-	 *		// genericCallback is fired.
-	 *		myEmitter.fire( 'myGroup' );
-	 *		// both genericCallback and specificCallback are fired.
-	 *		myEmitter.fire( 'myGroup:myEvent' );
-	 *		// genericCallback is fired even though there are no callbacks for "foo".
-	 *		myEmitter.fire( 'myGroup:foo' );
-	 *
-	 * An event callback can {@link module:utils/eventinfo~EventInfo#stop stop the event} and
-	 * set the {@link module:utils/eventinfo~EventInfo#return return value} of the {@link #fire} method.
+	 * Shorthand for {@link #listenTo `this.listenTo( this, event, callback, options )`} (it makes the emitter
+	 * listen on itself).
 	 *
 	 * @method #on
 	 * @param {String} event The name of the event.
@@ -80,7 +66,7 @@ const EmitterMixin = {
 
 	/**
 	 * Stops executing the callback on the given event.
-	 * Shorthand for {@link #stopListening this.stopListening( this, event, callback) }.
+	 * Shorthand for {@link #stopListening `this.stopListening( this, event, callback )`}.
 	 *
 	 * @method #off
 	 * @param {String} event The name of the event.
@@ -92,6 +78,23 @@ const EmitterMixin = {
 
 	/**
 	 * Registers a callback function to be executed when an event is fired in a specific (emitter) object.
+	 *
+	 * Events can be grouped in namespaces using `:`.
+	 * When namespaced event is fired, it additionally fires all callbacks for that namespace.
+	 *
+	 *		// myEmitter.on( ... ) is a shorthand for myEmitter.listenTo( myEmitter, ... ).
+	 *		myEmitter.on( 'myGroup', genericCallback );
+	 *		myEmitter.on( 'myGroup:myEvent', specificCallback );
+	 *
+	 *		// genericCallback is fired.
+	 *		myEmitter.fire( 'myGroup' );
+	 *		// both genericCallback and specificCallback are fired.
+	 *		myEmitter.fire( 'myGroup:myEvent' );
+	 *		// genericCallback is fired even though there are no callbacks for "foo".
+	 *		myEmitter.fire( 'myGroup:foo' );
+	 *
+	 * An event callback can {@link module:utils/eventinfo~EventInfo#stop stop the event} and
+	 * set the {@link module:utils/eventinfo~EventInfo#return return value} of the {@link #fire} method.
 	 *
 	 * @method #listenTo
 	 * @param {module:utils/emittermixin~Emitter} emitter The object that fires the event.
@@ -181,7 +184,7 @@ const EmitterMixin = {
 	 * * To stop listening to a specific callback.
 	 * * To stop listening to a specific event.
 	 * * To stop listening to all events fired by a specific object.
-	 * * To stop listening to all events fired by all object.
+	 * * To stop listening to all events fired by all objects.
 	 *
 	 * @method #stopListening
 	 * @param {module:utils/emittermixin~Emitter} [emitter] The object to stop listening to. If omitted, stops it for all objects.

--- a/tests/dom/emittermixin.js
+++ b/tests/dom/emittermixin.js
@@ -116,6 +116,46 @@ describe( 'DomEmitterMixin', () => {
 	} );
 
 	describe( 'stopListening', () => {
+		it( 'should stop listening to EmitterMixin events, specific event', () => {
+			const spy1 = testUtils.sinon.spy();
+			const spy2 = testUtils.sinon.spy();
+
+			domEmitter.listenTo( emitter, 'foo', spy1 );
+			domEmitter.listenTo( emitter, 'foo:bar', spy2 );
+
+			emitter.fire( 'foo:bar' );
+
+			sinon.assert.calledOnce( spy1 );
+			sinon.assert.calledOnce( spy2 );
+
+			domEmitter.stopListening( emitter, 'foo' );
+
+			emitter.fire( 'foo:bar' );
+
+			sinon.assert.calledOnce( spy1 );
+			sinon.assert.calledTwice( spy2 );
+		} );
+
+		it( 'should stop listening to EmitterMixin events, specific emitter', () => {
+			const spy1 = testUtils.sinon.spy();
+			const spy2 = testUtils.sinon.spy();
+
+			domEmitter.listenTo( emitter, 'foo', spy1 );
+			domEmitter.listenTo( emitter, 'foo:bar', spy2 );
+
+			emitter.fire( 'foo:bar' );
+
+			sinon.assert.calledOnce( spy1 );
+			sinon.assert.calledOnce( spy2 );
+
+			domEmitter.stopListening( emitter );
+
+			emitter.fire( 'foo:bar' );
+
+			sinon.assert.calledOnce( spy1 );
+			sinon.assert.calledOnce( spy2 );
+		} );
+
 		it( 'should stop listening to a specific event callback', () => {
 			const spy1 = testUtils.sinon.spy();
 			const spy2 = testUtils.sinon.spy();
@@ -132,6 +172,34 @@ describe( 'DomEmitterMixin', () => {
 			node.dispatchEvent( new Event( 'event2' ) );
 
 			sinon.assert.calledOnce( spy1 );
+			sinon.assert.calledTwice( spy2 );
+		} );
+
+		it( 'should stop listening to a specific event callback (only from the given node)', () => {
+			const spy1 = testUtils.sinon.spy();
+			const spy2 = testUtils.sinon.spy();
+
+			const node1 = document.createElement( 'div' );
+			const node2 = document.createElement( 'div' );
+
+			domEmitter.listenTo( node1, 'event1', spy1 );
+			domEmitter.listenTo( node1, 'event2', spy2 );
+			domEmitter.listenTo( node2, 'event1', spy1 );
+
+			node1.dispatchEvent( new Event( 'event1' ) );
+			node1.dispatchEvent( new Event( 'event2' ) );
+			node2.dispatchEvent( new Event( 'event1' ) );
+
+			sinon.assert.calledTwice( spy1 );
+			sinon.assert.calledOnce( spy2 );
+
+			domEmitter.stopListening( node1, 'event1', spy1 );
+
+			node1.dispatchEvent( new Event( 'event1' ) );
+			node1.dispatchEvent( new Event( 'event2' ) );
+			node2.dispatchEvent( new Event( 'event1' ) );
+
+			sinon.assert.calledThrice( spy1 );
 			sinon.assert.calledTwice( spy2 );
 		} );
 
@@ -192,26 +260,53 @@ describe( 'DomEmitterMixin', () => {
 			sinon.assert.calledOnce( spy2 );
 		} );
 
-		it( 'should stop listening to everything', () => {
+		it( 'should stop listening to all events from a specific node (only that node)', () => {
 			const spy1 = testUtils.sinon.spy();
 			const spy2 = testUtils.sinon.spy();
 
 			const node1 = document.createElement( 'div' );
 			const node2 = document.createElement( 'div' );
 
+			domEmitter.listenTo( node1, 'event', spy1 );
+			domEmitter.listenTo( node2, 'event', spy2 );
+
+			node1.dispatchEvent( new Event( 'event' ) );
+			node2.dispatchEvent( new Event( 'event' ) );
+
+			domEmitter.stopListening( node1 );
+
+			node1.dispatchEvent( new Event( 'event' ) );
+			node2.dispatchEvent( new Event( 'event' ) );
+
+			sinon.assert.calledOnce( spy1 );
+			sinon.assert.calledTwice( spy2 );
+		} );
+
+		it( 'should stop listening to everything', () => {
+			const spy1 = testUtils.sinon.spy();
+			const spy2 = testUtils.sinon.spy();
+			const spy3 = testUtils.sinon.spy();
+
+			const node1 = document.createElement( 'div' );
+			const node2 = document.createElement( 'div' );
+
 			domEmitter.listenTo( node1, 'event1', spy1 );
 			domEmitter.listenTo( node2, 'event2', spy2 );
+			domEmitter.listenTo( emitter, 'event3', spy3 );
 
 			node1.dispatchEvent( new Event( 'event1' ) );
 			node2.dispatchEvent( new Event( 'event2' ) );
+			emitter.fire( 'event3' );
 
 			domEmitter.stopListening();
 
 			node1.dispatchEvent( new Event( 'event1' ) );
 			node2.dispatchEvent( new Event( 'event2' ) );
+			emitter.fire( 'event3' );
 
 			sinon.assert.calledOnce( spy1 );
 			sinon.assert.calledOnce( spy2 );
+			sinon.assert.calledOnce( spy3 );
 		} );
 
 		it( 'should stop listening to everything what left', () => {
@@ -413,28 +508,35 @@ describe( 'DomEmitterMixin', () => {
 			const spy1b = testUtils.sinon.spy();
 			const spy1c = testUtils.sinon.spy();
 			const spy1d = testUtils.sinon.spy();
+			const spyEl2 = testUtils.sinon.spy();
+			const node2 = document.createElement( 'div' );
 
 			domEmitter.listenTo( node, 'test1', spy1a );
 			domEmitter.listenTo( node, 'test2', spy1b );
+			domEmitter.listenTo( node2, 'test1', spyEl2 );
 
 			const proxyEmitter = domEmitter._getProxyEmitter( node );
 			const spy2 = testUtils.sinon.spy( proxyEmitter, 'fire' );
 
 			node.dispatchEvent( new Event( 'test1' ) );
 			node.dispatchEvent( new Event( 'test2' ) );
+			node2.dispatchEvent( new Event( 'test1' ) );
 
 			sinon.assert.calledOnce( spy1a );
 			sinon.assert.calledOnce( spy1b );
 			sinon.assert.calledTwice( spy2 );
+			sinon.assert.calledOnce( spyEl2 );
 
 			domEmitter.stopListening();
 
 			node.dispatchEvent( new Event( 'test1' ) );
 			node.dispatchEvent( new Event( 'test2' ) );
+			node2.dispatchEvent( new Event( 'test1' ) );
 
 			sinon.assert.calledOnce( spy1a );
 			sinon.assert.calledOnce( spy1b );
 			sinon.assert.calledTwice( spy2 );
+			sinon.assert.calledOnce( spyEl2 );
 
 			// Attach same event again.
 			domEmitter.listenTo( node, 'test1', spy1c );
@@ -455,6 +557,7 @@ describe( 'DomEmitterMixin', () => {
 			sinon.assert.calledOnce( spy1d );
 			sinon.assert.calledTwice( spy2 );
 			sinon.assert.calledTwice( spy3 );
+			sinon.assert.calledOnce( spyEl2 );
 		} );
 
 		// #187

--- a/tests/emittermixin.js
+++ b/tests/emittermixin.js
@@ -323,6 +323,22 @@ describe( 'EmitterMixin', () => {
 
 			sinon.assert.calledWithExactly( spy, sinon.match.instanceOf( EventInfo ), 1, 2, 3 );
 		} );
+
+		it( 'should be removed only after exact event fired', () => {
+			const spy1 = sinon.spy();
+			const spy2 = sinon.spy();
+
+			emitter.on( 'foo', spy1 );
+			emitter.once( 'foo', spy2 );
+
+			emitter.fire( 'foo:bar' );
+			emitter.fire( 'foo' );
+			emitter.fire( 'foo:bar' );
+			emitter.fire( 'foo' );
+
+			sinon.assert.callCount( spy1, 4 );
+			sinon.assert.calledTwice( spy2 );
+		} );
 	} );
 
 	describe( 'off', () => {

--- a/tests/emittermixin.js
+++ b/tests/emittermixin.js
@@ -314,23 +314,6 @@ describe( 'EmitterMixin', () => {
 			sinon.assert.calledTwice( spy3 );
 		} );
 
-		it( 'should be called just once for namespaced event when calling general event', () => {
-			const spy1 = sinon.spy();
-			const spy2 = sinon.spy();
-			const spy3 = sinon.spy();
-
-			emitter.on( 'foo', spy1 );
-			emitter.once( 'foo', spy2 );
-			emitter.on( 'foo', spy3 );
-
-			emitter.fire( 'foo:bar' );
-			emitter.fire( 'foo:bar' );
-
-			sinon.assert.calledTwice( spy1 );
-			sinon.assert.calledOnce( spy2 );
-			sinon.assert.calledTwice( spy3 );
-		} );
-
 		it( 'should have proper arguments', () => {
 			const spy = sinon.spy();
 
@@ -510,13 +493,6 @@ describe( 'EmitterMixin', () => {
 			sinon.assert.calledThrice( spyFoo );
 			sinon.assert.calledTwice( spyBar );
 			sinon.assert.calledOnce( spyBaz );
-		} );
-
-		it( 'should not fail on empty callback', () => {
-			listener.listenTo( emitter, 'foo' );
-
-			emitter.fire( 'foo' );
-			emitter.fire( 'foo:bar' );
 		} );
 	} );
 

--- a/tests/emittermixin.js
+++ b/tests/emittermixin.js
@@ -280,7 +280,7 @@ describe( 'EmitterMixin', () => {
 	} );
 
 	describe( 'once', () => {
-		it( 'should be called just once', () => {
+		it( 'should be called just once for general event', () => {
 			const spy1 = sinon.spy();
 			const spy2 = sinon.spy();
 			const spy3 = sinon.spy();
@@ -291,6 +291,40 @@ describe( 'EmitterMixin', () => {
 
 			emitter.fire( 'test' );
 			emitter.fire( 'test' );
+
+			sinon.assert.calledTwice( spy1 );
+			sinon.assert.calledOnce( spy2 );
+			sinon.assert.calledTwice( spy3 );
+		} );
+
+		it( 'should be called just once for namespaced event', () => {
+			const spy1 = sinon.spy();
+			const spy2 = sinon.spy();
+			const spy3 = sinon.spy();
+
+			emitter.on( 'foo:bar', spy1 );
+			emitter.once( 'foo:bar', spy2 );
+			emitter.on( 'foo:bar', spy3 );
+
+			emitter.fire( 'foo:bar' );
+			emitter.fire( 'foo:bar' );
+
+			sinon.assert.calledTwice( spy1 );
+			sinon.assert.calledOnce( spy2 );
+			sinon.assert.calledTwice( spy3 );
+		} );
+
+		it( 'should be called just once for namespaced event when calling general event', () => {
+			const spy1 = sinon.spy();
+			const spy2 = sinon.spy();
+			const spy3 = sinon.spy();
+
+			emitter.on( 'foo', spy1 );
+			emitter.once( 'foo', spy2 );
+			emitter.on( 'foo', spy3 );
+
+			emitter.fire( 'foo:bar' );
+			emitter.fire( 'foo:bar' );
 
 			sinon.assert.calledTwice( spy1 );
 			sinon.assert.calledOnce( spy2 );
@@ -330,9 +364,30 @@ describe( 'EmitterMixin', () => {
 			sinon.assert.calledThrice( spy3 );
 		} );
 
+		it( 'should remove all callbacks for event', () => {
+			const spy1 = sinon.spy();
+			const spy2 = sinon.spy();
+
+			emitter.on( 'test', spy1 );
+			emitter.on( 'test', spy2 );
+
+			emitter.fire( 'test' );
+
+			emitter.off( 'test' );
+
+			emitter.fire( 'test' );
+			emitter.fire( 'test' );
+
+			sinon.assert.calledOnce( spy1 );
+			sinon.assert.calledOnce( spy2 );
+		} );
+
 		it( 'should not fail with unknown events', () => {
 			emitter.off( 'foo', () => {} );
 			emitter.off( 'foo:bar', () => {} );
+
+			emitter.off( 'foo' );
+			emitter.off( 'foo:bar' );
 		} );
 
 		it( 'should remove all entries for the same callback', () => {
@@ -352,6 +407,34 @@ describe( 'EmitterMixin', () => {
 
 			sinon.assert.callCount( spy1, 2 );
 			sinon.assert.callCount( spy2, 4 );
+		} );
+
+		it( 'should not remove all namespaced entries when removing namespace inner group', () => {
+			const spy1 = sinon.spy().named( 'foo' );
+			const spy2 = sinon.spy().named( 'foo:bar' );
+			const spy3 = sinon.spy().named( 'foo:bar:baz' );
+			const spy4 = sinon.spy().named( 'foo:bar:baz:abc' );
+
+			emitter.on( 'foo', spy1 );
+			emitter.on( 'foo:bar', spy2 );
+			emitter.on( 'foo:bar:baz', spy3 );
+			emitter.on( 'foo:bar:baz:abc', spy4 );
+
+			emitter.fire( 'foo:bar:baz:abc' );
+
+			sinon.assert.calledOnce( spy1 );
+			sinon.assert.calledOnce( spy2 );
+			sinon.assert.calledOnce( spy3 );
+			sinon.assert.calledOnce( spy4 );
+
+			emitter.off( 'foo:bar' );
+
+			emitter.fire( 'foo:bar:baz:abc' );
+
+			sinon.assert.calledTwice( spy1 );
+			sinon.assert.calledOnce( spy2 );
+			sinon.assert.calledTwice( spy3 );
+			sinon.assert.calledTwice( spy4 );
 		} );
 
 		it( 'should properly remove callbacks for namespaced events', () => {
@@ -404,19 +487,36 @@ describe( 'EmitterMixin', () => {
 		it( 'should correctly listen to namespaced events', () => {
 			const spyFoo = sinon.spy();
 			const spyBar = sinon.spy();
+			const spyBaz = sinon.spy();
 
 			listener.listenTo( emitter, 'foo', spyFoo );
 			listener.listenTo( emitter, 'foo:bar', spyBar );
+			listener.listenTo( emitter, 'foo:bar:baz', spyBaz );
 
-			emitter.fire( 'foo:bar' );
+			emitter.fire( 'foo:bar:baz' );
 
 			sinon.assert.calledOnce( spyFoo );
 			sinon.assert.calledOnce( spyBar );
+			sinon.assert.calledOnce( spyBaz );
+
+			emitter.fire( 'foo:bar' );
+
+			sinon.assert.calledTwice( spyFoo );
+			sinon.assert.calledTwice( spyBar );
+			sinon.assert.calledOnce( spyBaz );
 
 			emitter.fire( 'foo' );
 
-			sinon.assert.calledTwice( spyFoo );
-			sinon.assert.calledOnce( spyBar );
+			sinon.assert.calledThrice( spyFoo );
+			sinon.assert.calledTwice( spyBar );
+			sinon.assert.calledOnce( spyBaz );
+		} );
+
+		it( 'should not fail on empty callback', () => {
+			listener.listenTo( emitter, 'foo' );
+
+			emitter.fire( 'foo' );
+			emitter.fire( 'foo:bar' );
 		} );
 	} );
 
@@ -465,42 +565,62 @@ describe( 'EmitterMixin', () => {
 		it( 'should stop listening to all events from given emitter', () => {
 			const spy1 = sinon.spy();
 			const spy2 = sinon.spy();
+			const spy3 = sinon.spy();
+			const spy4 = sinon.spy();
 
 			listener.listenTo( emitter, 'event1', spy1 );
 			listener.listenTo( emitter, 'event2', spy2 );
+			listener.listenTo( emitter, 'foo', spy3 );
+			listener.listenTo( emitter, 'foo:bar:baz', spy4 );
 
 			emitter.fire( 'event1' );
 			emitter.fire( 'event2' );
+			emitter.fire( 'foo:bar:baz' );
 
 			listener.stopListening( emitter );
 
 			emitter.fire( 'event1' );
 			emitter.fire( 'event2' );
+			emitter.fire( 'foo:bar:baz' );
 
 			sinon.assert.calledOnce( spy1 );
 			sinon.assert.calledOnce( spy2 );
+			sinon.assert.calledOnce( spy3 );
+			sinon.assert.calledOnce( spy4 );
 		} );
 
 		it( 'should stop listening to everything', () => {
 			const spy1 = sinon.spy();
 			const spy2 = sinon.spy();
+			const spy3 = sinon.spy();
+			const spy4 = sinon.spy();
 
 			const emitter1 = getEmitterInstance();
 			const emitter2 = getEmitterInstance();
 
 			listener.listenTo( emitter1, 'event1', spy1 );
 			listener.listenTo( emitter2, 'event2', spy2 );
+			listener.listenTo( emitter1, 'foo', spy3 );
+			listener.listenTo( emitter1, 'foo:bar:baz', spy4 );
 
 			emitter1.fire( 'event1' );
 			emitter2.fire( 'event2' );
+			emitter1.fire( 'foo' );
+			emitter1.fire( 'foo:bar' );
+			emitter1.fire( 'foo:bar:baz' );
 
 			listener.stopListening();
 
 			emitter1.fire( 'event1' );
 			emitter2.fire( 'event2' );
+			emitter1.fire( 'foo' );
+			emitter1.fire( 'foo:bar' );
+			emitter1.fire( 'foo:bar:baz' );
 
 			sinon.assert.calledOnce( spy1 );
 			sinon.assert.calledOnce( spy2 );
+			sinon.assert.calledThrice( spy3 );
+			sinon.assert.calledOnce( spy4 );
 		} );
 
 		it( 'should not stop other emitters when a non-listened emitter is provided', () => {
@@ -521,16 +641,37 @@ describe( 'EmitterMixin', () => {
 		it( 'should correctly stop listening to namespaced events', () => {
 			const spyFoo = sinon.spy();
 			const spyBar = sinon.spy();
+			const spyBaz = sinon.spy();
 
 			listener.listenTo( emitter, 'foo', spyFoo );
 			listener.listenTo( emitter, 'foo:bar', spyBar );
+			listener.listenTo( emitter, 'foo:bar:baz', spyBaz );
 
 			listener.stopListening( emitter, 'foo' );
 
-			emitter.fire( 'foo:bar' );
+			emitter.fire( 'foo:bar:baz' );
 
 			sinon.assert.notCalled( spyFoo );
 			sinon.assert.calledOnce( spyBar );
+			sinon.assert.calledOnce( spyBaz );
+		} );
+
+		it( 'should correctly stop listening to namespaced events when removing specialised event', () => {
+			const spyFoo = sinon.spy();
+			const spyBar = sinon.spy();
+			const spyBaz = sinon.spy();
+
+			listener.listenTo( emitter, 'foo', spyFoo );
+			listener.listenTo( emitter, 'foo:bar', spyBar );
+			listener.listenTo( emitter, 'foo:bar:baz', spyBaz );
+
+			listener.stopListening( emitter, 'foo:bar' );
+
+			emitter.fire( 'foo:bar:baz' );
+
+			sinon.assert.calledOnce( spyFoo );
+			sinon.assert.notCalled( spyBar );
+			sinon.assert.calledOnce( spyBaz );
 		} );
 
 		it( 'should not fail with unknown events', () => {
@@ -540,12 +681,20 @@ describe( 'EmitterMixin', () => {
 			listener.stopListening( emitter, 'foo:bar' );
 		} );
 
+		it( 'should not fail with unknown emitter', () => {
+			listener.listenTo( emitter, 'foo:bar', () => {} );
+
+			listener.stopListening( {}, 'foo', () => {} );
+			listener.stopListening( {}, 'foo:bar', () => {} );
+			listener.stopListening( {}, 'foo' );
+			listener.stopListening( {}, 'foo:bar' );
+			listener.stopListening( {} );
+		} );
+
 		it( 'should not fail with unknown callbacks', () => {
 			const spy = sinon.spy();
 
-			listener.listenTo( emitter, 'foo', () => {
-				spy();
-			} );
+			listener.listenTo( emitter, 'foo', spy );
 			listener.stopListening( emitter, 'foo', () => {} );
 
 			emitter.fire( 'foo' );

--- a/tests/emittermixin.js
+++ b/tests/emittermixin.js
@@ -331,7 +331,8 @@ describe( 'EmitterMixin', () => {
 		} );
 
 		it( 'should not fail with unknown events', () => {
-			emitter.off( 'test', () => {} );
+			emitter.off( 'foo', () => {} );
+			emitter.off( 'foo:bar', () => {} );
 		} );
 
 		it( 'should remove all entries for the same callback', () => {
@@ -530,6 +531,26 @@ describe( 'EmitterMixin', () => {
 
 			sinon.assert.notCalled( spyFoo );
 			sinon.assert.calledOnce( spyBar );
+		} );
+
+		it( 'should not fail with unknown events', () => {
+			listener.stopListening( emitter, 'foo', () => {} );
+			listener.stopListening( emitter, 'foo:bar', () => {} );
+			listener.stopListening( emitter, 'foo' );
+			listener.stopListening( emitter, 'foo:bar' );
+		} );
+
+		it( 'should not fail with unknown callbacks', () => {
+			const spy = sinon.spy();
+
+			listener.listenTo( emitter, 'foo', () => {
+				spy();
+			} );
+			listener.stopListening( emitter, 'foo', () => {} );
+
+			emitter.fire( 'foo' );
+
+			sinon.assert.calledOnce( spy );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Aligned behaviors of `EmitterMixin` methods responsible for adding end removing listeners. Closes #144.

The `emitter.on` now has the same behavior as `emitter.listenTo( emitter )` as well as `emitter.off` is the same as `emitter.stopListening( emitter )`.


---

### Additional information

* Requires https://github.com/ckeditor/ckeditor5-utils/pull/189 to be closed first as this branch is based on previous work.
* This PR clean up `on`/`listenTo` and `off`/`stopListening` so the `on`/`off` are purely shorthands for base methods.
* I had to make minor changes to internal `Proxy` in `DomEmitterMixin` as it used `listenTo`/`on` in pretty convoluted way. I've renamed `Proxy` methods to not confuse them with `EmitterMixin` ones.
* Only changes besides `EmitterMixin` that were required were in `DomEmitterMixin`.
