### PR TITLE
Removed a dot at the end of error message.

### DIFF
--- a/src/ckeditorerror.js
+++ b/src/ckeditorerror.js
@@ -82,5 +82,5 @@ export function attachLinkToDocumentation( message ) {
 		return message;
 	}
 
-	return message + ` Read more: ${ DOCUMENTATION_URL }#${ matchedErrorName[ 1 ] }.\n`;
+	return message + ` Read more: ${ DOCUMENTATION_URL }#${ matchedErrorName[ 1 ] }\n`;
 }

--- a/tests/ckeditorerror.js
+++ b/tests/ckeditorerror.js
@@ -56,7 +56,7 @@ describe( 'CKEditorError', () => {
 		const error = new CKEditorError( 'model-schema-no-item: Specified item cannot be found.' );
 
 		const errorMessage = 'model-schema-no-item: Specified item cannot be found. ' +
-			`Read more: ${ DOCUMENTATION_URL }#model-schema-no-item.\n`;
+			`Read more: ${ DOCUMENTATION_URL }#model-schema-no-item\n`;
 
 		expect( error ).to.have.property( 'message', errorMessage );
 	} );
@@ -65,7 +65,7 @@ describe( 'CKEditorError', () => {
 		const error = new CKEditorError( 'model-schema-no-item: Specified item cannot be found.', { foo: 1, bar: 2 } );
 
 		const errorMessage = 'model-schema-no-item: Specified item cannot be found. ' +
-			`Read more: ${ DOCUMENTATION_URL }#model-schema-no-item.\n ` +
+			`Read more: ${ DOCUMENTATION_URL }#model-schema-no-item\n ` +
 			'{"foo":1,"bar":2}';
 
 		expect( error ).to.have.property( 'message', errorMessage );

--- a/tests/log.js
+++ b/tests/log.js
@@ -38,7 +38,7 @@ describe( 'log', () => {
 			log.warn( 'model-schema-no-item: Specified item cannot be found.' );
 
 			const logMessage = 'model-schema-no-item: Specified item cannot be found. ' +
-				`Read more: ${ DOCUMENTATION_URL }#model-schema-no-item.\n`;
+				`Read more: ${ DOCUMENTATION_URL }#model-schema-no-item\n`;
 
 			sinon.assert.calledOnce( spy );
 			sinon.assert.calledWith( spy, logMessage );
@@ -66,7 +66,7 @@ describe( 'log', () => {
 			log.error( 'model-schema-no-item: Specified item cannot be found.' );
 
 			const logMessage = 'model-schema-no-item: Specified item cannot be found. ' +
-				`Read more: ${ DOCUMENTATION_URL }#model-schema-no-item.\n`;
+				`Read more: ${ DOCUMENTATION_URL }#model-schema-no-item\n`;
 
 			sinon.assert.calledOnce( spy );
 			sinon.assert.calledWith( spy, logMessage );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Removed a period at the end of an error message because some browsers included the period in links to errors. Closes #193.
