### PR TITLE
Don't throw error when trying to unbind attribute that is not bound.

### DIFF
--- a/src/observablemixin.js
+++ b/src/observablemixin.js
@@ -216,6 +216,12 @@ const ObservableMixin = {
 
 			unbindAttrs.forEach( attrName => {
 				const binding = boundAttributes.get( attrName );
+
+				// Nothing to do if the binding is not defined
+				if ( !binding ) {
+					return;
+				}
+
 				let toObservable, toAttr, toAttrs, toAttrBindings;
 
 				binding.to.forEach( to => {

--- a/tests/observablemixin.js
+++ b/tests/observablemixin.js
@@ -739,6 +739,14 @@ describe( 'Observable', () => {
 			observable.unbind();
 		} );
 
+		it( 'should not fail when unbinding non-binded property', () => {
+			const observable = new Observable();
+
+			observable.bind( 'foo' ).to( car, 'color' );
+
+			observable.unbind( 'bar' );
+		} );
+
 		it( 'should throw when non-string attribute is passed', () => {
 			expect( () => {
 				car.unbind( new Date() );

--- a/tests/observablemixin.js
+++ b/tests/observablemixin.js
@@ -739,12 +739,12 @@ describe( 'Observable', () => {
 			observable.unbind();
 		} );
 
-		it( 'should not fail when unbinding non-binded property', () => {
+		it( 'should not fail when unbinding attribute that is not bound', () => {
 			const observable = new Observable();
 
 			observable.bind( 'foo' ).to( car, 'color' );
 
-			observable.unbind( 'bar' );
+			expect( () => observable.unbind( 'bar' ) ).to.not.throw();
 		} );
 
 		it( 'should throw when non-string attribute is passed', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Enhancement: Don't throw error when trying to unbind attribute that is not bound. Closes #5.

---

### Additional information

* Small fix I suppose.
