### PR TITLE
Fix exception that occur after dragging the selection through the image

### DIFF
--- a/src/dom/rect.js
+++ b/src/dom/rect.js
@@ -7,6 +7,8 @@
  * @module utils/dom/rect
  */
 
+/* global Node */
+
 import isRange from './isrange';
 import isWindow from './iswindow';
 import isElement from '../lib/lodash/isElement';
@@ -361,12 +363,19 @@ export default class Rect {
 		// If there's no client rects for the Range, use parent container's bounding rect
 		// instead and adjust rect's width to simulate the actual geometry of such range.
 		// https://github.com/ckeditor/ckeditor5-utils/issues/153
+		// https://github.com/ckeditor/ckeditor5-ui/issues/317
 		else {
-			const startContainerRect = new Rect( range.startContainer.getBoundingClientRect() );
-			startContainerRect.right = startContainerRect.left;
-			startContainerRect.width = 0;
+			let startContainer = range.startContainer;
 
-			rects.push( startContainerRect );
+			if ( startContainer.nodeType === Node.TEXT_NODE ) {
+				startContainer = startContainer.parentNode;
+			}
+
+			const rect = new Rect( startContainer.getBoundingClientRect() );
+			rect.right = rect.left;
+			rect.width = 0;
+
+			rects.push( rect );
 		}
 
 		return rects;

--- a/tests/dom/rect.js
+++ b/tests/dom/rect.js
@@ -965,6 +965,27 @@ describe( 'Rect', () => {
 			expect( rects ).to.have.length( 1 );
 			assertRect( rects[ 0 ], expectedGeometry );
 		} );
+
+		// https://github.com/ckeditor/ckeditor5-ui/issues/317
+		it( 'should return rects for a text node\'s parent (collapsed, no Range rects available)', () => {
+			const range = document.createRange();
+			const element = document.createElement( 'div' );
+			const textNode = document.createTextNode( 'abc' );
+			element.appendChild( textNode );
+
+			range.setStart( textNode, 3 );
+			range.collapse();
+			testUtils.sinon.stub( range, 'getClientRects' ).returns( [] );
+			testUtils.sinon.stub( element, 'getBoundingClientRect' ).returns( geometry );
+
+			const expectedGeometry = Object.assign( {}, geometry );
+			expectedGeometry.right = expectedGeometry.left;
+			expectedGeometry.width = 0;
+
+			const rects = Rect.getDomRangeRects( range );
+			expect( rects ).to.have.length( 1 );
+			assertRect( rects[ 0 ], expectedGeometry );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Added fallback for `Rect.getDomRangeRects()` if the given range starts in text node. Closes ckeditor/ckeditor5-ui#317.
