### PR TITLE
Implement isText() helper

### DIFF
--- a/src/dom/istext.js
+++ b/src/dom/istext.js
@@ -1,0 +1,18 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module utils/dom/istext
+ */
+
+/**
+ * Checks if the object is a native DOM Text node.
+ *
+ * @param {*} obj
+ * @returns {Boolean}
+ */
+export default function isText( obj ) {
+	return Object.prototype.toString.call( obj ) == '[object Text]';
+}

--- a/src/dom/rect.js
+++ b/src/dom/rect.js
@@ -7,13 +7,12 @@
  * @module utils/dom/rect
  */
 
-/* global Node */
-
 import isRange from './isrange';
 import isWindow from './iswindow';
 import isElement from '../lib/lodash/isElement';
 import getBorderWidths from './getborderwidths';
 import log from '../log';
+import isText from './istext';
 
 /**
  * A helper class representing a `ClientRect` object, e.g. value returned by
@@ -367,7 +366,7 @@ export default class Rect {
 		else {
 			let startContainer = range.startContainer;
 
-			if ( startContainer.nodeType === Node.TEXT_NODE ) {
+			if ( isText( startContainer ) ) {
 				startContainer = startContainer.parentNode;
 			}
 

--- a/src/dom/scroll.js
+++ b/src/dom/scroll.js
@@ -9,7 +9,7 @@
 
 import isRange from './isrange';
 import Rect from './rect';
-import isText from '../../../ckeditor5-engine/node_modules/@ckeditor/ckeditor5-utils/src/dom/istext';
+import isText from './istext';
 
 const utils = {};
 

--- a/src/dom/scroll.js
+++ b/src/dom/scroll.js
@@ -3,14 +3,13 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global Node */
-
 /**
  * @module utils/dom/scroll
  */
 
 import isRange from './isrange';
 import Rect from './rect';
+import isText from '../../../ckeditor5-engine/node_modules/@ckeditor/ckeditor5-utils/src/dom/istext';
 
 const utils = {};
 
@@ -255,7 +254,7 @@ function getParentElement( elementOrRange ) {
 		let parent = elementOrRange.commonAncestorContainer;
 
 		// If a Range is attached to the Text, use the closest element ancestor.
-		if ( parent.nodeType == Node.TEXT_NODE ) {
+		if ( isText( parent ) ) {
 			parent = parent.parentNode;
 		}
 

--- a/tests/dom/istext.js
+++ b/tests/dom/istext.js
@@ -1,0 +1,41 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* global document, Text */
+
+import isText from '../../src/dom/istext';
+
+describe( 'isText()', () => {
+	it( 'detects native DOM Text', () => {
+		expect( isText( new Text( 'foo' ) ) ).to.be.true;
+
+		expect( isText( 'foo' ) ).to.be.false;
+		expect( isText( {} ) ).to.be.false;
+		expect( isText( null ) ).to.be.false;
+		expect( isText( undefined ) ).to.be.false;
+		expect( isText( new Date() ) ).to.be.false;
+		expect( isText( 42 ) ).to.be.false;
+		expect( isText( document.createElement( 'div' ) ) ).to.be.false;
+		expect( isText( document.createDocumentFragment() ) ).to.be.false;
+		expect( isText( document.createComment( 'a' ) ) ).to.be.false;
+	} );
+
+	it( 'works for texts in an iframe', done => {
+		const iframe = document.createElement( 'iframe' );
+
+		iframe.addEventListener( 'load', () => {
+			const iframeDocument = iframe.contentWindow.document;
+
+			const textNode = iframeDocument.createTextNode( 'foo' );
+
+			expect( isText( textNode ) ).to.equal( true );
+
+			iframe.remove();
+			done();
+		} );
+
+		document.body.appendChild( iframe );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Introduced `isText()` helper. Closes #214.

---

### Additional information
PRs in other packages:
- https://github.com/ckeditor/ckeditor5-engine/pull/1259
