### PR TITLE
Rename isDomNode() to isNode()

### DIFF
--- a/src/dom/emittermixin.js
+++ b/src/dom/emittermixin.js
@@ -10,7 +10,7 @@
 import { default as EmitterMixin, _getEmitterListenedTo, _setEmitterId } from '../emittermixin';
 import uid from '../uid';
 import extend from '../lib/lodash/extend';
-import isDomNode from './isdomnode';
+import isNode from './isnode';
 import isWindow from './iswindow';
 
 /**
@@ -53,7 +53,7 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 	listenTo( emitter, ...rest ) {
 		// Check if emitter is an instance of DOM Node. If so, replace the argument with
 		// corresponding ProxyEmitter (or create one if not existing).
-		if ( isDomNode( emitter ) || isWindow( emitter ) ) {
+		if ( isNode( emitter ) || isWindow( emitter ) ) {
 			const proxy = this._getProxyEmitter( emitter ) || new ProxyEmitter( emitter );
 
 			proxy.attach( ...rest );
@@ -82,7 +82,7 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 	 */
 	stopListening( emitter, event, callback ) {
 		// Check if emitter is an instance of DOM Node. If so, replace the argument with corresponding ProxyEmitter.
-		if ( isDomNode( emitter ) || isWindow( emitter ) ) {
+		if ( isNode( emitter ) || isWindow( emitter ) ) {
 			const proxy = this._getProxyEmitter( emitter );
 
 			// Element has no listeners.

--- a/src/dom/isnode.js
+++ b/src/dom/isnode.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module utils/dom/isdomnode
+ * @module utils/dom/isnode
  */
 
 /**
@@ -13,7 +13,7 @@
  * @param {*} obj
  * @returns {Boolean}
  */
-export default function isDomNode( obj ) {
+export default function isNode( obj ) {
 	if ( obj ) {
 		if ( obj.defaultView ) {
 			return obj instanceof obj.defaultView.Document;

--- a/tests/dom/isdomnode.js
+++ b/tests/dom/isdomnode.js
@@ -5,20 +5,20 @@
 
 /* global document, window */
 
-import isDomNode from '../../src/dom/isdomnode';
+import isNode from '../../src/dom/isnode';
 
-describe( 'isDomNode()', () => {
+describe( 'isNode()', () => {
 	it( 'detects native DOM nodes', () => {
-		expect( isDomNode( document ) ).to.be.true;
-		expect( isDomNode( document.createElement( 'div' ) ) ).to.be.true;
-		expect( isDomNode( document.createTextNode( 'Foo' ) ) ).to.be.true;
+		expect( isNode( document ) ).to.be.true;
+		expect( isNode( document.createElement( 'div' ) ) ).to.be.true;
+		expect( isNode( document.createTextNode( 'Foo' ) ) ).to.be.true;
 
-		expect( isDomNode( {} ) ).to.be.false;
-		expect( isDomNode( null ) ).to.be.false;
-		expect( isDomNode( undefined ) ).to.be.false;
-		expect( isDomNode( new Date() ) ).to.be.false;
-		expect( isDomNode( 42 ) ).to.be.false;
-		expect( isDomNode( window ) ).to.be.false;
+		expect( isNode( {} ) ).to.be.false;
+		expect( isNode( null ) ).to.be.false;
+		expect( isNode( undefined ) ).to.be.false;
+		expect( isNode( new Date() ) ).to.be.false;
+		expect( isNode( 42 ) ).to.be.false;
+		expect( isNode( window ) ).to.be.false;
 	} );
 
 	it( 'works for nodes in an iframe', done => {
@@ -27,11 +27,11 @@ describe( 'isDomNode()', () => {
 		iframe.addEventListener( 'load', () => {
 			const iframeDocument = iframe.contentWindow.document;
 
-			expect( isDomNode( iframeDocument ) ).to.be.true;
-			expect( isDomNode( iframeDocument.createElement( 'div' ) ) ).to.be.true;
-			expect( isDomNode( iframeDocument.createTextNode( 'Foo' ) ) ).to.be.true;
+			expect( isNode( iframeDocument ) ).to.be.true;
+			expect( isNode( iframeDocument.createElement( 'div' ) ) ).to.be.true;
+			expect( isNode( iframeDocument.createTextNode( 'Foo' ) ) ).to.be.true;
 
-			expect( isDomNode( iframe.contentWindow ) ).to.be.false;
+			expect( isNode( iframe.contentWindow ) ).to.be.false;
 
 			iframe.remove();
 			done();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Renamed `isDomNode()` to `isNode()`. Closes #219.

BREAKING CHANGE: `isDomNode()` was renamed to `isNode()`.