### PR TITLE
Fix: parentNode error.

### DIFF
--- a/src/dom/scroll.js
+++ b/src/dom/scroll.js
@@ -45,24 +45,24 @@ export function scrollViewportToShowTarget( { target, viewportOffset = 0 } ) {
 			firstAncestorToScroll = getParentElement( currentFrame );
 		}
 
-		if (firstAncestorToScroll) {
+		if ( firstAncestorToScroll ) {
 			// Scroll the target's ancestors first. Once done, scrolling the viewport is easy.
-			scrollAncestorsToShowRect(firstAncestorToScroll, () => {
+			scrollAncestorsToShowRect( firstAncestorToScroll, () => {
 				// Note: If the target does not belong to the current window **directly**,
 				// i.e. it resides in an iframe belonging to the window, obtain the target's rect
 				// in the coordinates of the current window. By default, a Rect returns geometry
 				// relative to the current window's viewport. To make it work in a parent window,
 				// it must be shifted.
-				return getRectRelativeToWindow(target, currentWindow);
-			});
+				return getRectRelativeToWindow( target, currentWindow );
+			} );
 
 			// Obtain the rect of the target after it has been scrolled within its ancestors.
 			// It's time to scroll the viewport.
-			const targetRect = getRectRelativeToWindow(target, currentWindow);
+			const targetRect = getRectRelativeToWindow( target, currentWindow );
 
-			scrollWindowToShowRect(currentWindow, targetRect, viewportOffset);
+			scrollWindowToShowRect( currentWindow, targetRect, viewportOffset );
 
-			if (currentWindow.parent != currentWindow) {
+			if ( currentWindow.parent != currentWindow ) {
 				// Keep the reference to the <iframe> element the "previous current window" was
 				// rendered within. It will be useful to re–calculate the rect of the target
 				// in the parent window's relative geometry. The target's rect must be shifted
@@ -74,7 +74,7 @@ export function scrollViewportToShowTarget( { target, viewportOffset = 0 } ) {
 			}
 		} else {
 			currentWindow = null;
-		}	
+		}
 	}
 }
 
@@ -253,8 +253,8 @@ function getWindow( elementOrRange ) {
 // @private
 // @param {HTMLElement|Range} firstRect
 // @returns {HTMLelement}
-function getParentElement(elementOrRange) {
-	if (!elementOrRange) {
+function getParentElement( elementOrRange ) {
+	if ( !elementOrRange ) {
 		return null;
 	}
 

--- a/src/dom/scroll.js
+++ b/src/dom/scroll.js
@@ -45,32 +45,36 @@ export function scrollViewportToShowTarget( { target, viewportOffset = 0 } ) {
 			firstAncestorToScroll = getParentElement( currentFrame );
 		}
 
-		// Scroll the target's ancestors first. Once done, scrolling the viewport is easy.
-		scrollAncestorsToShowRect( firstAncestorToScroll, () => {
-			// Note: If the target does not belong to the current window **directly**,
-			// i.e. it resides in an iframe belonging to the window, obtain the target's rect
-			// in the coordinates of the current window. By default, a Rect returns geometry
-			// relative to the current window's viewport. To make it work in a parent window,
-			// it must be shifted.
-			return getRectRelativeToWindow( target, currentWindow );
-		} );
+		if (firstAncestorToScroll) {
+			// Scroll the target's ancestors first. Once done, scrolling the viewport is easy.
+			scrollAncestorsToShowRect(firstAncestorToScroll, () => {
+				// Note: If the target does not belong to the current window **directly**,
+				// i.e. it resides in an iframe belonging to the window, obtain the target's rect
+				// in the coordinates of the current window. By default, a Rect returns geometry
+				// relative to the current window's viewport. To make it work in a parent window,
+				// it must be shifted.
+				return getRectRelativeToWindow(target, currentWindow);
+			});
 
-		// Obtain the rect of the target after it has been scrolled within its ancestors.
-		// It's time to scroll the viewport.
-		const targetRect = getRectRelativeToWindow( target, currentWindow );
+			// Obtain the rect of the target after it has been scrolled within its ancestors.
+			// It's time to scroll the viewport.
+			const targetRect = getRectRelativeToWindow(target, currentWindow);
 
-		scrollWindowToShowRect( currentWindow, targetRect, viewportOffset );
+			scrollWindowToShowRect(currentWindow, targetRect, viewportOffset);
 
-		if ( currentWindow.parent != currentWindow ) {
-			// Keep the reference to the <iframe> element the "previous current window" was
-			// rendered within. It will be useful to re–calculate the rect of the target
-			// in the parent window's relative geometry. The target's rect must be shifted
-			// by it's iframe's position.
-			currentFrame = currentWindow.frameElement;
-			currentWindow = currentWindow.parent;
+			if (currentWindow.parent != currentWindow) {
+				// Keep the reference to the <iframe> element the "previous current window" was
+				// rendered within. It will be useful to re–calculate the rect of the target
+				// in the parent window's relative geometry. The target's rect must be shifted
+				// by it's iframe's position.
+				currentFrame = currentWindow.frameElement;
+				currentWindow = currentWindow.parent;
+			} else {
+				currentWindow = null;
+			}
 		} else {
 			currentWindow = null;
-		}
+		}	
 	}
 }
 
@@ -249,7 +253,11 @@ function getWindow( elementOrRange ) {
 // @private
 // @param {HTMLElement|Range} firstRect
 // @returns {HTMLelement}
-function getParentElement( elementOrRange ) {
+function getParentElement(elementOrRange) {
+	if (!elementOrRange) {
+		return null;
+	}
+
 	if ( isRange( elementOrRange ) ) {
 		let parent = elementOrRange.commonAncestorContainer;
 


### PR DESCRIPTION
This validations fix the problem with "Enter" inside an iframe.
I have this issue using ckeditor inside an Angular project.

I think this PR also fix [#930](https://github.com/ckeditor/ckeditor5/issues/930)

## Adicional information

Because the main project isn't an Angular project,  my project (let's call FOO) have to live inside an iframe.
To make sure that our preview isn't affected by FOO style, the preview also live inside an iframe. So the structure is like this:
```typescript
MAIN PROJECT:
   - FOO iframe:
      - PREVIEW iframe (ckeditor live's here)
```

When we press enter, backspace or delete, the error ```Uncaught TypeError: Cannot read property 'parentNode' of null``` is throw.

I have tested this PR proposal inside FOO and the error was gone.