### PR TITLE
t/ckeditor5/930: Error should not be thrown when scrolling the viewport from within an iframe in a different domain

### DIFF
--- a/src/dom/scroll.js
+++ b/src/dom/scroll.js
@@ -45,24 +45,24 @@ export function scrollViewportToShowTarget( { target, viewportOffset = 0 } ) {
 			firstAncestorToScroll = getParentElement( currentFrame );
 		}
 
-		if (firstAncestorToScroll) {
+		if ( firstAncestorToScroll ) {
 			// Scroll the target's ancestors first. Once done, scrolling the viewport is easy.
-			scrollAncestorsToShowRect(firstAncestorToScroll, () => {
+			scrollAncestorsToShowRect( firstAncestorToScroll, () => {
 				// Note: If the target does not belong to the current window **directly**,
 				// i.e. it resides in an iframe belonging to the window, obtain the target's rect
 				// in the coordinates of the current window. By default, a Rect returns geometry
 				// relative to the current window's viewport. To make it work in a parent window,
 				// it must be shifted.
-				return getRectRelativeToWindow(target, currentWindow);
-			});
+				return getRectRelativeToWindow( target, currentWindow );
+			} );
 
 			// Obtain the rect of the target after it has been scrolled within its ancestors.
 			// It's time to scroll the viewport.
-			const targetRect = getRectRelativeToWindow(target, currentWindow);
+			const targetRect = getRectRelativeToWindow( target, currentWindow );
 
-			scrollWindowToShowRect(currentWindow, targetRect, viewportOffset);
+			scrollWindowToShowRect( currentWindow, targetRect, viewportOffset );
 
-			if (currentWindow.parent != currentWindow) {
+			if ( currentWindow.parent != currentWindow ) {
 				// Keep the reference to the <iframe> element the "previous current window" was
 				// rendered within. It will be useful to re–calculate the rect of the target
 				// in the parent window's relative geometry. The target's rect must be shifted
@@ -74,7 +74,7 @@ export function scrollViewportToShowTarget( { target, viewportOffset = 0 } ) {
 			}
 		} else {
 			currentWindow = null;
-		}	
+		}
 	}
 }
 
@@ -253,8 +253,8 @@ function getWindow( elementOrRange ) {
 // @private
 // @param {HTMLElement|Range} firstRect
 // @returns {HTMLelement}
-function getParentElement(elementOrRange) {
-	if (!elementOrRange) {
+function getParentElement( elementOrRange ) {
+	if ( !elementOrRange ) {
 		return null;
 	}
 

--- a/src/dom/scroll.js
+++ b/src/dom/scroll.js
@@ -45,32 +45,36 @@ export function scrollViewportToShowTarget( { target, viewportOffset = 0 } ) {
 			firstAncestorToScroll = getParentElement( currentFrame );
 		}
 
-		// Scroll the target's ancestors first. Once done, scrolling the viewport is easy.
-		scrollAncestorsToShowRect( firstAncestorToScroll, () => {
-			// Note: If the target does not belong to the current window **directly**,
-			// i.e. it resides in an iframe belonging to the window, obtain the target's rect
-			// in the coordinates of the current window. By default, a Rect returns geometry
-			// relative to the current window's viewport. To make it work in a parent window,
-			// it must be shifted.
-			return getRectRelativeToWindow( target, currentWindow );
-		} );
+		if (firstAncestorToScroll) {
+			// Scroll the target's ancestors first. Once done, scrolling the viewport is easy.
+			scrollAncestorsToShowRect(firstAncestorToScroll, () => {
+				// Note: If the target does not belong to the current window **directly**,
+				// i.e. it resides in an iframe belonging to the window, obtain the target's rect
+				// in the coordinates of the current window. By default, a Rect returns geometry
+				// relative to the current window's viewport. To make it work in a parent window,
+				// it must be shifted.
+				return getRectRelativeToWindow(target, currentWindow);
+			});
 
-		// Obtain the rect of the target after it has been scrolled within its ancestors.
-		// It's time to scroll the viewport.
-		const targetRect = getRectRelativeToWindow( target, currentWindow );
+			// Obtain the rect of the target after it has been scrolled within its ancestors.
+			// It's time to scroll the viewport.
+			const targetRect = getRectRelativeToWindow(target, currentWindow);
 
-		scrollWindowToShowRect( currentWindow, targetRect, viewportOffset );
+			scrollWindowToShowRect(currentWindow, targetRect, viewportOffset);
 
-		if ( currentWindow.parent != currentWindow ) {
-			// Keep the reference to the <iframe> element the "previous current window" was
-			// rendered within. It will be useful to re–calculate the rect of the target
-			// in the parent window's relative geometry. The target's rect must be shifted
-			// by it's iframe's position.
-			currentFrame = currentWindow.frameElement;
-			currentWindow = currentWindow.parent;
+			if (currentWindow.parent != currentWindow) {
+				// Keep the reference to the <iframe> element the "previous current window" was
+				// rendered within. It will be useful to re–calculate the rect of the target
+				// in the parent window's relative geometry. The target's rect must be shifted
+				// by it's iframe's position.
+				currentFrame = currentWindow.frameElement;
+				currentWindow = currentWindow.parent;
+			} else {
+				currentWindow = null;
+			}
 		} else {
 			currentWindow = null;
-		}
+		}	
 	}
 }
 
@@ -249,7 +253,11 @@ function getWindow( elementOrRange ) {
 // @private
 // @param {HTMLElement|Range} firstRect
 // @returns {HTMLelement}
-function getParentElement( elementOrRange ) {
+function getParentElement(elementOrRange) {
+	if (!elementOrRange) {
+		return null;
+	}
+
 	if ( isRange( elementOrRange ) ) {
 		let parent = elementOrRange.commonAncestorContainer;
 

--- a/tests/dom/scroll.js
+++ b/tests/dom/scroll.js
@@ -291,6 +291,15 @@ describe( 'scrollViewportToShowTarget()', () => {
 			sinon.assert.calledWithExactly( iframeWindow.scrollTo, 100, -100 );
 			sinon.assert.calledWithExactly( window.scrollTo, 1820, 1520 );
 		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/930
+		it( 'should not throw if the child frame has no access to the #frameElement of the parent', () => {
+			sinon.stub( iframeWindow, 'frameElement' ).get( () => null );
+
+			expect( () => {
+				scrollViewportToShowTarget( { target } );
+			} ).to.not.throw();
+		} );
 	} );
 
 	// Note: Because everything is a mock, scrolling the firstAncestor doesn't really change


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Error should not be thrown when scrolling the viewport from within an iframe in a different domain. Closes ckeditor/ckeditor5#930.

---

### Additional information

It is a follow-up of https://github.com/ckeditor/ckeditor5-utils/pull/240/files because I was unable to push to the original PR.  I also simplified the solution and provided a valid test.

As for the cause of the issue, the error is thrown when the child and the parent windows have different domain/ports. In such situation, [for security reasons, `frameElement` is unavailable](https://developer.mozilla.org/en-US/docs/Web/API/Window/frameElement).

If worked for me in my sandbox because I used the same server. JSFiddle uses a different domain for live snippets and hence the error.