### PR TITLE
[Docs] Fix some typos

### DIFF
--- a/src/ckeditorerror.js
+++ b/src/ckeditorerror.js
@@ -51,9 +51,9 @@ export default class CKEditorError extends Error {
 		this.name = 'CKEditorError';
 
 		/**
-		 * The additional error data passed to the constructor.
+		 * The additional error data passed to the constructor. Undefined if none was passed.
 		 *
-		 * @member {Object}
+		 * @member {Object | undefined}
 		 */
 		this.data = data;
 	}

--- a/src/collection.js
+++ b/src/collection.js
@@ -290,7 +290,7 @@ export default class Collection {
 	 * @param {Function} callback
 	 * @param {Object} callback.item
 	 * @param {Number} callback.index
-	 * @params {Object} ctx Context in which the `callback` will be called.
+	 * @param {Object} ctx Context in which the `callback` will be called.
 	 * @returns {Array} The result of mapping.
 	 */
 	map( callback, ctx ) {
@@ -303,8 +303,8 @@ export default class Collection {
 	 * @param {Function} callback
 	 * @param {Object} callback.item
 	 * @param {Number} callback.index
+	 * @param {Object} ctx Context in which the `callback` will be called.
 	 * @returns {Object} The item for which `callback` returned a true value.
-	 * @params {Object} ctx Context in which the `callback` will be called.
 	 */
 	find( callback, ctx ) {
 		return this._items.find( callback, ctx );
@@ -316,7 +316,7 @@ export default class Collection {
 	 * @param {Function} callback
 	 * @param {Object} callback.item
 	 * @param {Number} callback.index
-	 * @params {Object} ctx Context in which the `callback` will be called.
+	 * @param {Object} ctx Context in which the `callback` will be called.
 	 * @returns {Object[]} The array with matching items.
 	 */
 	filter( callback, ctx ) {

--- a/src/dom/createelement.js
+++ b/src/dom/createelement.js
@@ -20,8 +20,8 @@ import { isString } from 'lodash-es';
  *
  * @param {Document} doc Document used to create element.
  * @param {String} name Name of the element.
- * @param {Object} attributes Object keys will become attributes keys and object values will became attributes values.
- * @param {Node|String|Array.<Node|String>} children Child or array of children. Strings will be automatically turned
+ * @param {Object|null} [attributes] Object keys will become attributes keys and object values will became attributes values.
+ * @param {Node|String|Array.<Node|String>} [children] Child or array of children. Strings will be automatically turned
  * into Text nodes.
  * @returns {Element} Created element.
  */

--- a/src/dom/getborderwidths.js
+++ b/src/dom/getborderwidths.js
@@ -11,7 +11,7 @@
  * Returns an object containing CSS border widths of a specified HTML element.
  *
  * @param {HTMLElement} element An element which has CSS borders.
- * @param {Object} An object containing `top`, `left`, `right` and `bottom` properties
+ * @returns {Object} An object containing `top`, `left`, `right` and `bottom` properties
  * with numerical values of the `border-[top,left,right,bottom]-width` CSS styles.
  */
 export default function getBorderWidths( element ) {

--- a/src/dom/getpositionedancestor.js
+++ b/src/dom/getpositionedancestor.js
@@ -12,7 +12,7 @@ import global from './global';
 /**
  * For a given element, returns the nearest ancestor element which CSS position is not "static".
  *
- * @param {HTMLElement} element Native DOM element to be checked.
+ * @param {HTMLElement} [element] Native DOM element to be checked.
  * @returns {HTMLElement|null}
  */
 export default function getPositionedAncestor( element ) {

--- a/src/dom/position.js
+++ b/src/dom/position.js
@@ -67,7 +67,7 @@ import { isFunction } from 'lodash-es';
  *
  *		// The best position which fits into document.body and the viewport. May be useful
  *		// to set proper class on the `element`.
- *		console.log( name ); -> "myNorthEastPosition"
+ *		console.log( name ); // -> "myNorthEastPosition"
  *
  *		// Using the absolute coordinates which has been found to position the element
  *		// as in the diagram depicting the "myNorthEastPosition" position.

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -635,5 +635,5 @@ function removeCallback( emitter, event, callback ) {
  *
  * @method #to
  * @param {module:utils/emittermixin~Emitter} emitter An `EmitterMixin` instance which is the destination for delegated events.
- * @param {String|Function} nameOrFunction A custom event name or function which converts the original name string.
+ * @param {String|Function} [nameOrFunction] A custom event name or function which converts the original name string.
  */

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -43,7 +43,7 @@ export const keyCodes = generateKnownKeyCodes();
  *
  * Note: Key names are matched with {@link module:utils/keyboard~keyCodes} in a case-insensitive way.
  *
- * @param {String|module:utils/keyboard~KeystrokeInfo} Key name (see {@link module:utils/keyboard~keyCodes})
+ * @param {String|module:utils/keyboard~KeystrokeInfo} key name (see {@link module:utils/keyboard~keyCodes})
  * or a keystroke data object.
  * @returns {Number} Key or keystroke code.
  */

--- a/src/keystrokehandler.js
+++ b/src/keystrokehandler.js
@@ -81,7 +81,7 @@ export default class KeystrokeHandler {
 	 * @param {String|Array.<String|Number>} keystroke Keystroke defined in a format accepted by
 	 * the {@link module:utils/keyboard~parseKeystroke} function.
 	 * @param {Function} callback A function called with the
-	 * {@link module:engine/view/observer/keyobserver~KeyEventData key event data} object and
+	 * {@link module:utils/keyboard~KeystrokeInfo keystroke info} object and
 	 * a helper to both `preventDefault` and `stopPropagation` of the event.
 	 * @param {Object} [options={}] Additional options.
 	 * @param {module:utils/priorities~PriorityString|Number} [options.priority='normal'] The priority of the keystroke
@@ -114,7 +114,7 @@ export default class KeystrokeHandler {
 	/**
 	 * Triggers a keystroke handler for a specified key combination, if such a keystroke was {@link #set defined}.
 	 *
-	 * @param {module:engine/view/observer/keyobserver~KeyEventData} keyEvtData Key event data.
+	 * @param {module:utils/keyboard~KeystrokeInfo} keyEvtData Key event data.
 	 * @returns {Boolean} Whether the keystroke was handled.
 	 */
 	press( keyEvtData ) {

--- a/src/locale.js
+++ b/src/locale.js
@@ -44,7 +44,7 @@ export default class Locale {
 		 *
 		 * @method #t
 		 * @param {String} str The string to translate.
-		 * @param {String[]} values Values that should be used to interpolate the string.
+		 * @param {String[]} [values] Values that should be used to interpolate the string.
 		 */
 		this.t = ( ...args ) => this._t( ...args );
 	}

--- a/src/mapsequal.js
+++ b/src/mapsequal.js
@@ -10,6 +10,8 @@
 /**
  * Checks whether given {Map}s are equal, that is has same size and same key-value pairs.
  *
+ * @param {Map} mapA The first map to compare.
+ * @param {Map} mapB The second map to compare.
  * @returns {Boolean} `true` if given maps are equal, `false` otherwise.
  */
 export default function mapsEqual( mapA, mapB ) {


### PR DESCRIPTION
Examples for fixes can be found in `tests/`.

There are some typos I don't know how to fix:

- **KeystrokeInfo**: the properties `altKey`, `ctrlKey` and `shiftKey` are all optional.
- **Options**: the properties `fitInViewport` and `limiter` are all optional.
- **Emitter#delegate**: type for `events` is `...String`.
- **Observable#bind**: type for `bindProperties` is `...String`.
- **Observable#unbind**: type for `unbindProperties` is `...String`.