### PR TITLE
T/257:  Clone returned values from Config.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@
  * @module utils/config
  */
 
-import { isPlainObject } from 'lodash-es';
+import { isPlainObject, cloneDeep } from 'lodash-es';
 
 /**
  * Handles a configuration dictionary.
@@ -198,7 +198,7 @@ export default class Config {
 		}
 
 		// Always returns undefined for non existing configuration
-		return source ? source[ name ] : undefined;
+		return source ? cloneDeep( source[ name ] ) : undefined;
 	}
 
 	/**

--- a/tests/config.js
+++ b/tests/config.js
@@ -334,7 +334,7 @@ describe( 'Config', () => {
 			expect( config.get( 'resize.icon.path' ) ).to.equal( 'xyz' );
 		} );
 
-		it( 'should retrieve a object of the configuration', () => {
+		it( 'should retrieve an object of the configuration', () => {
 			const resize = config.get( 'resize' );
 
 			expect( resize ).to.be.an( 'object' );

--- a/tests/config.js
+++ b/tests/config.js
@@ -19,7 +19,14 @@ describe( 'Config', () => {
 					path: 'xyz'
 				}
 			},
-			toolbar: 'top'
+			toolbar: 'top',
+			options: {
+				foo: [
+					{ bar: 'b' },
+					{ bar: 'a' },
+					{ bar: 'z' }
+				]
+			}
 		} );
 	} );
 
@@ -370,6 +377,34 @@ describe( 'Config', () => {
 			expect( () => {
 				config.resize.maxHeight;
 			} ).to.throw();
+		} );
+
+		it( 'should not be possible to alter config object by altering returned value', () => {
+			expect( config.get( 'resize.icon.path' ) ).to.equal( 'xyz' );
+
+			const icon = config.get( 'resize.icon' );
+			icon.path = 'foo/bar';
+
+			expect( config.get( 'resize.icon.path' ) ).to.equal( 'xyz' );
+
+			const resize = config.get( 'resize' );
+			resize.icon.path = 'foo/baz';
+
+			expect( config.get( 'resize.icon.path' ) ).to.equal( 'xyz' );
+		} );
+
+		it( 'should not be possible to alter array in config by altering returned value', () => {
+			expect( config.get( 'options.foo' ) ).to.deep.equal( [ { bar: 'b' }, { bar: 'a' }, { bar: 'z' } ] );
+
+			const fooOptions = config.get( 'options.foo' );
+			fooOptions.pop();
+
+			expect( config.get( 'options.foo' ) ).to.deep.equal( [ { bar: 'b' }, { bar: 'a' }, { bar: 'z' } ] );
+
+			const options = config.get( 'options' );
+			options.foo.pop();
+
+			expect( config.get( 'options.foo' ) ).to.deep.equal( [ { bar: 'b' }, { bar: 'a' }, { bar: 'z' } ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduce cloning of returned values from Config. Closes #257.

---

### Additional information

* Also changed in repos:
  * ckfinder: https://github.com/ckeditor/ckeditor5-ckfinder/tree/t/ckeditor5-utils/257
  * heading: https://github.com/ckeditor/ckeditor5-heading/tree/t/ckeditor5-utils/257
  * image: https://github.com/ckeditor/ckeditor5-image/tree/t/ckeditor5-utils/257
