### PR TITLE
Leave DOM Elements in configuration object returned from editor.config.get().

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@
  * @module utils/config
  */
 
-import { isPlainObject, cloneDeep } from 'lodash-es';
+import { isPlainObject, isElement, cloneDeepWith } from 'lodash-es';
 
 /**
  * Handles a configuration dictionary.
@@ -197,8 +197,8 @@ export default class Config {
 			source = source[ part ];
 		}
 
-		// Always returns undefined for non existing configuration
-		return source ? cloneDeep( source[ name ] ) : undefined;
+		// Always returns undefined for non existing configuration.
+		return source ? cloneConfig( source[ name ] ) : undefined;
 	}
 
 	/**
@@ -214,4 +214,20 @@ export default class Config {
 			this._setToTarget( target, key, configuration[ key ], isDefine );
 		} );
 	}
+}
+
+// Clones configuration object or value.
+// @param {*} source Source configuration
+// @returns {*} Cloned configuration value.
+function cloneConfig( source ) {
+	return cloneDeepWith( source, leaveDOMReferences );
+}
+
+// A customizer function for cloneDeepWith.
+// It will leave references to DOM Elements instead of cloning them.
+//
+// @param {*} value
+// @returns {Element|undefined}
+function leaveDOMReferences( value ) {
+	return isElement( value ) ? value : undefined;
 }

--- a/tests/config.js
+++ b/tests/config.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
+/* global document */
+
 import Config from '../src/config';
 
 describe( 'Config', () => {
@@ -433,6 +435,28 @@ describe( 'Config', () => {
 
 			// But array members should remain the same contents should be equal:
 			expect( pluginsAgain ).to.deep.equal( plugins );
+		} );
+
+		it( 'should return DOM nodes references from config array', () => {
+			const foo = document.createElement( 'div' );
+
+			config.set( 'node', foo );
+			config.set( 'nodes', [ foo ] );
+
+			expect( config.get( 'node' ) ).to.equal( foo );
+			expect( config.get( 'nodes' ) ).to.deep.equal( [ foo ] );
+
+			const nodes = config.get( 'nodes' );
+
+			expect( nodes[ 0 ] ).to.equal( foo );
+
+			const nodesAgain = config.get( 'nodes' );
+
+			// The returned array should be a new instance:
+			expect( nodesAgain ).to.not.equal( nodes );
+
+			// But array members should remain the same contents should be equal:
+			expect( nodesAgain ).to.deep.equal( nodes );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: DOM Elements will not be cloned when returned from config.get. Closes #264.

---

### Additional information

* @oskarwrobel: please check if the solution works for you.
