### PR TITLE
Replaced `for..of` with `Array.prototype.forEach`

### DIFF
--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -237,7 +237,9 @@ const EmitterMixin = {
 					this._delegations = new Map();
 				}
 
-				for ( const eventName of events ) {
+				// Originally there was a for..of loop which unfortunately caused an error in Babel that didn't allow
+				// build an application. See: https://github.com/ckeditor/ckeditor5-react/issues/40.
+				events.forEach( eventName => {
 					const destinations = this._delegations.get( eventName );
 
 					if ( !destinations ) {
@@ -245,7 +247,7 @@ const EmitterMixin = {
 					} else {
 						destinations.set( emitter, nameOrFunction );
 					}
-				}
+				} );
 			}
 		};
 	},


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Replaced `for..of` statement in `EventEmitter` with `Array.prototype.forEach`. This changes allows building a React application using `create-react-app@2`. Closes ckeditor/ckeditor5-react#40.
