### PR TITLE
Added `isSafari` property to `env` module

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -47,7 +47,7 @@ const env = {
 	 * @static
 	 * @member {Boolean} module:utils/env~env#isSafari
 	 */
-	isSafari: isSafari( userAgent ),
+	isSafari: isSafari( userAgent )
 };
 
 export default env;

--- a/src/env.js
+++ b/src/env.js
@@ -39,7 +39,15 @@ const env = {
 	 * @static
 	 * @member {Boolean} module:utils/env~env#isEdge
 	 */
-	isGecko: isGecko( userAgent )
+	isGecko: isGecko( userAgent ),
+
+	/**
+	 * Indicates that the application is running in Safari.
+	 *
+	 * @static
+	 * @member {Boolean} module:utils/env~env#isSafari
+	 */
+	isSafari: isSafari( userAgent ),
 };
 
 export default env;
@@ -72,4 +80,14 @@ export function isEdge( userAgent ) {
  */
 export function isGecko( userAgent ) {
 	return !!userAgent.match( /gecko\/\d+/ );
+}
+
+/**
+ * Checks if User Agent represented by the string is Safari.
+ *
+ * @param {String} userAgent **Lowercase** `navigator.userAgent` string.
+ * @returns {Boolean} Whether User Agent is Safari or not.
+ */
+export function isSafari( userAgent ) {
+	return userAgent.indexOf( ' applewebkit/' ) > -1 && userAgent.indexOf( 'chrome' ) === -1;
 }

--- a/tests/env.js
+++ b/tests/env.js
@@ -3,16 +3,13 @@
  * For licensing, see LICENSE.md.
  */
 
-import env, { isEdge, isMac, isGecko } from '../src/env';
+import env, { isEdge, isMac, isGecko, isSafari } from '../src/env';
 
 function toLowerCase( str ) {
 	return str.toLowerCase();
 }
 
 describe( 'Env', () => {
-	beforeEach( () => {
-	} );
-
 	it( 'is an object', () => {
 		expect( env ).to.be.an( 'object' );
 	} );
@@ -32,6 +29,12 @@ describe( 'Env', () => {
 	describe( 'isGecko', () => {
 		it( 'is a boolean', () => {
 			expect( env.isGecko ).to.be.a( 'boolean' );
+		} );
+	} );
+
+	describe( 'isSafari', () => {
+		it( 'is a boolean', () => {
+			expect( env.isSafari ).to.be.a( 'boolean' );
 		} );
 	} );
 
@@ -102,5 +105,30 @@ describe( 'Env', () => {
 				'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36'
 			) ) ).to.be.false;
 		} );
+	} );
+
+	describe( 'isSafari()', () => {
+		/* eslint-disable max-len */
+		it( 'returns true for Safari UA strings', () => {
+			expect( isSafari( toLowerCase(
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.3 Safari/605.1.15'
+			) ) ).to.be.true;
+			expect( isSafari( toLowerCase(
+				'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1'
+			) ) ).to.be.true;
+		} );
+
+		it( 'returns false for non-Safari UA strings', () => {
+			expect( isSafari( toLowerCase(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36'
+			) ) ).to.be.false;
+			expect( isSafari( toLowerCase(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:65.0) Gecko/20100101 Firefox/65.0'
+			) ) ).to.be.false;
+			expect( isSafari( toLowerCase(
+				'Mozilla/5.0 (Linux; Android 7.1; Mi A1 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36'
+			) ) ).to.be.false;
+		} );
+		/* eslint-enable max-len */
 	} );
 } );

--- a/tests/env.js
+++ b/tests/env.js
@@ -113,6 +113,7 @@ describe( 'Env', () => {
 			expect( isSafari( toLowerCase(
 				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.3 Safari/605.1.15'
 			) ) ).to.be.true;
+
 			expect( isSafari( toLowerCase(
 				'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1'
 			) ) ).to.be.true;
@@ -122,9 +123,11 @@ describe( 'Env', () => {
 			expect( isSafari( toLowerCase(
 				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36'
 			) ) ).to.be.false;
+
 			expect( isSafari( toLowerCase(
 				'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:65.0) Gecko/20100101 Firefox/65.0'
 			) ) ).to.be.false;
+
 			expect( isSafari( toLowerCase(
 				'Mozilla/5.0 (Linux; Android 7.1; Mi A1 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36'
 			) ) ).to.be.false;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added `isSafari` property and `isSafari()` function to the `env` module. See: ckeditor/ckeditor5#1463.

---

### Additional information

Required for: https://github.com/ckeditor/ckeditor5-widget/pull/79.
