### PR TITLE
t/ckeditor5-ui/515: The `getOptimalPosition()` utility should consider element ancestors with `overflow` to avoid cropping

### DIFF
--- a/src/dom/getancestorwithoverflow.js
+++ b/src/dom/getancestorwithoverflow.js
@@ -1,0 +1,29 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module utils/dom/getancestorwithoverflow
+ */
+
+import global from './global';
+
+/**
+ * For a given element, returns the nearest ancestor element which CSS `overflow` is not `visible`.
+ *
+ * @param {HTMLElement} element The native DOM element to be checked.
+ * @returns {HTMLElement|null}
+ */
+export default function getAncestorWithOveflow( element ) {
+	while ( element && element.tagName.toLowerCase() != 'html' ) {
+		if ( global.window.getComputedStyle( element ).overflow != 'visible' ) {
+			return element;
+		}
+
+		element = element.parentElement;
+	}
+
+	return null;
+}
+


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `getOptimalPosition()` utility should consider element ancestors with `overflow` to avoid cropping. Closes ckeditor/ckeditor5-ui#515.
