### PR TITLE
Introduce assertEqualMarkup() test util

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@ckeditor/ckeditor5-editor-classic": "^12.1.4",
     "@ckeditor/ckeditor5-core": "^12.3.0",
     "@ckeditor/ckeditor5-engine": "^14.0.0",
+    "assertion-error": "^1.1.0",
     "eslint": "^5.5.0",
     "eslint-config-ckeditor5": "^2.0.0",
     "husky": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint": "^5.5.0",
     "eslint-config-ckeditor5": "^2.0.0",
     "husky": "^1.3.1",
+    "js-beautify": "^1.10.2",
     "lint-staged": "^7.0.0"
   },
   "engines": {

--- a/tests/_utils-tests/utils.js
+++ b/tests/_utils-tests/utils.js
@@ -3,10 +3,11 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+import { AssertionError } from 'chai';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import ObservableMixin from '../../src/observablemixin';
 import EmitterMixin from '../../src/emittermixin';
-import { createObserver } from '../_utils/utils';
+import { assertEqualMarkup, createObserver } from '../_utils/utils';
 
 describe( 'utils - testUtils', () => {
 	afterEach( () => {
@@ -79,6 +80,106 @@ describe( 'utils - testUtils', () => {
 				observable.foo = 2;
 				expect( spy.callCount ).to.equal( 1 );
 			} );
+		} );
+	} );
+
+	describe( 'assertEqualMarkup()', () => {
+		it( 'should not throw for equal strings', () => {
+			expect( assertEqualMarkup( 'foo', 'foo' ) ).to.not.throw;
+		} );
+
+		it( 'should throw AssertionError for not equal strings', () => {
+			try {
+				assertEqualMarkup( 'foo', 'bar' );
+			} catch ( assertionError ) {
+				expect( assertionError ).to.be.instanceOf( AssertionError );
+			}
+		} );
+
+		it( 'should throw with default (short) message', () => {
+			try {
+				assertEqualMarkup( 'foo', 'bar' );
+			} catch ( assertionError ) {
+				expect( assertionError.message ).to.equal( 'Expected markup strings to be equal' );
+			}
+		} );
+
+		it( 'should throw with passed message', () => {
+			try {
+				assertEqualMarkup( 'foo', 'bar', 'baz' );
+			} catch ( assertionError ) {
+				expect( assertionError.message ).to.equal( 'baz' );
+			}
+		} );
+
+		it( 'should format actual string', () => {
+			try {
+				assertEqualMarkup( '<div><p><span>foo</span></p></div>', 'bar' );
+			} catch ( assertionError ) {
+				expect( assertionError.actual ).to.equal(
+					'<div>\n' +
+					'  <p><span>foo</span></p>\n' +
+					'</div>'
+				);
+			}
+		} );
+
+		it( 'should format expected string', () => {
+			try {
+				assertEqualMarkup( 'foo', '<div><p><span>foo</span></p></div>' );
+			} catch ( assertionError ) {
+				expect( assertionError.expected ).to.equal(
+					'<div>\n' +
+					'  <p><span>foo</span></p>\n' +
+					'</div>'
+				);
+			}
+		} );
+
+		it( 'should format model text node with attributes as inline', () => {
+			try {
+				assertEqualMarkup( 'foo', '<paragraph><$text bold="true">foo</$text></paragraph>' );
+			} catch ( assertionError ) {
+				expect( assertionError.expected ).to.equal(
+					'<paragraph><$text bold="true">foo</$text></paragraph>'
+				);
+			}
+		} );
+
+		it( 'should format nested model structure properly', () => {
+			try {
+				assertEqualMarkup( 'foo',
+					'<blockQuote>' +
+						'<table>' +
+							'<tableRow>' +
+								'<tableCell>' +
+									'<paragraph><$text bold="true">foo</$text></paragraph>' +
+								'</tableCell>' +
+								'<tableCell>' +
+									'<paragraph><$text bold="true">bar</$text></paragraph>' +
+									'<paragraph><$text bold="true">baz</$text></paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>' +
+					'</blockQuote>'
+				);
+			} catch ( assertionError ) {
+				expect( assertionError.expected ).to.equal(
+					'<blockQuote>\n' +
+					'  <table>\n' +
+					'    <tableRow>\n' +
+					'      <tableCell>\n' +
+					'        <paragraph><$text bold="true">foo</$text></paragraph>\n' +
+					'      </tableCell>\n' +
+					'      <tableCell>\n' +
+					'        <paragraph><$text bold="true">bar</$text></paragraph>\n' +
+					'        <paragraph><$text bold="true">baz</$text></paragraph>\n' +
+					'      </tableCell>\n' +
+					'    </tableRow>\n' +
+					'  </table>\n' +
+					'</blockQuote>'
+				);
+			}
 		} );
 	} );
 } );

--- a/tests/_utils-tests/utils.js
+++ b/tests/_utils-tests/utils.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import { AssertionError } from 'chai';
+import AssertionError from 'assertion-error';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import ObservableMixin from '../../src/observablemixin';
 import EmitterMixin from '../../src/emittermixin';

--- a/tests/_utils/utils.js
+++ b/tests/_utils/utils.js
@@ -152,7 +152,7 @@ export function assertCKEditorError( err, message, editorThatShouldBeFindableFro
  *
  * This util can be used to test HTML strings and string containing serialized model.
  *
- *		// Will throw error for chaijs
+ *		// Will throw an error that is handled as assertion error by Chai.
  *		assertEqualMarkup(
  *			'<paragraph><$text foo="bar">baz</$text></paragraph>',
  *			'<paragraph><$text foo="bar">baaz</$text></paragraph>',
@@ -172,6 +172,7 @@ export function assertEqualMarkup( actual, expected, message = 'Expected markup 
 	}
 }
 
+// Renames the $text occurrences as it is not properly formatted by the beautifier - it is tread as a block.
 const TEXT_TAG_PLACEHOLDER = 'span data-cke="true"';
 const TEXT_TAG_PLACEHOLDER_REGEXP = new RegExp( TEXT_TAG_PLACEHOLDER, 'g' );
 

--- a/tests/_utils/utils.js
+++ b/tests/_utils/utils.js
@@ -5,6 +5,10 @@
 
 /* global console:false */
 
+import { AssertionError } from 'chai';
+// eslint-disable-next-line camelcase
+import { html_beautify } from 'js-beautify/js/lib/beautify-html';
+
 import EmitterMixin from '../../src/emittermixin';
 import CKEditorError from '../../src/ckeditorerror';
 import areConnectedThroughProperties from '../../src/areconnectedthroughproperties';
@@ -140,4 +144,44 @@ export function assertCKEditorError( err, message, editorThatShouldBeFindableFro
 	if ( data ) {
 		expect( err.data ).to.deep.equal( data );
 	}
+}
+
+/**
+ * An assertion util test whether two given strings containing markup language are equal.
+ * Unlike `expect().to.equal()` form Chai assertion library, this util formats the markup before showing a diff.
+ *
+ * This util can be used to test HTML strings and string containing serialized model.
+ *
+ *		// Will throw error for chaijs
+ *		assertEqualMarkup(
+ *			'<paragraph><$text foo="bar">baz</$text></paragraph>',
+ *			'<paragraph><$text foo="bar">baaz</$text></paragraph>',
+ *		);
+ *
+ * @param {String} actual An actual string.
+ * @param {String} expected An expected string.
+ * @param {message} [expected="Expected two markup strings to be equal"] Optional error message.
+ */
+export function assertEqualMarkup( actual, expected, message = 'Expected two markup strings to be equal' ) {
+	if ( actual != expected ) {
+		throw new AssertionError( message, {
+			actual: formatMarkup( actual ),
+			expected: formatMarkup( expected ),
+			showDiff: true
+		} );
+	}
+}
+
+const TEXT_TAG_PLACEHOLDER = 'span data-cke="true"';
+const TEXT_TAG_PLACEHOLDER_REGEXP = new RegExp( TEXT_TAG_PLACEHOLDER, 'g' );
+
+function formatMarkup( string ) {
+	const htmlSafeString = string.replace( /\$text/g, TEXT_TAG_PLACEHOLDER );
+
+	const beautifiedMarkup = html_beautify( htmlSafeString, {
+		indent_size: 2,
+		space_in_empty_paren: true
+	} );
+
+	return beautifiedMarkup.replace( TEXT_TAG_PLACEHOLDER_REGEXP, '$text' );
 }

--- a/tests/_utils/utils.js
+++ b/tests/_utils/utils.js
@@ -5,7 +5,7 @@
 
 /* global console:false */
 
-import { AssertionError } from 'chai';
+import AssertionError from 'assertion-error';
 // eslint-disable-next-line camelcase
 import { html_beautify } from 'js-beautify/js/lib/beautify-html';
 
@@ -160,9 +160,9 @@ export function assertCKEditorError( err, message, editorThatShouldBeFindableFro
  *
  * @param {String} actual An actual string.
  * @param {String} expected An expected string.
- * @param {message} [expected="Expected two markup strings to be equal"] Optional error message.
+ * @param {String} [message="Expected two markup strings to be equal"] Optional error message.
  */
-export function assertEqualMarkup( actual, expected, message = 'Expected two markup strings to be equal' ) {
+export function assertEqualMarkup( actual, expected, message = 'Expected markup strings to be equal' ) {
 	if ( actual != expected ) {
 		throw new AssertionError( message, {
 			actual: formatMarkup( actual ),

--- a/tests/_utils/utils.js
+++ b/tests/_utils/utils.js
@@ -6,8 +6,7 @@
 /* global console:false */
 
 import AssertionError from 'assertion-error';
-// eslint-disable-next-line camelcase
-import { html_beautify } from 'js-beautify/js/lib/beautify-html';
+import { html_beautify as beautify } from 'js-beautify/js/lib/beautify-html';
 
 import EmitterMixin from '../../src/emittermixin';
 import CKEditorError from '../../src/ckeditorerror';
@@ -179,7 +178,7 @@ const TEXT_TAG_PLACEHOLDER_REGEXP = new RegExp( TEXT_TAG_PLACEHOLDER, 'g' );
 function formatMarkup( string ) {
 	const htmlSafeString = string.replace( /\$text/g, TEXT_TAG_PLACEHOLDER );
 
-	const beautifiedMarkup = html_beautify( htmlSafeString, {
+	const beautifiedMarkup = beautify( htmlSafeString, {
 		indent_size: 2,
 		space_in_empty_paren: true
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduce `assertEqualMarkup()` test util method. Closes ckeditor/ckeditor5-paste-from-office#14.

---

### Additional information

* ~I'll check if we can use it somewhere else other then PFO - tables?~
* 2 New dev dependencies:
    - 1. js-beautify for formatting HTML code: https://www.npmjs.com/package/js-beautify
    - 2. assertion-error for throwing chai compatible assertion errors (already added by chai from the testing environment).

Required by https://github.com/ckeditor/ckeditor5-engine/pull/1779