### PR TITLE
Introduced `CKEditorError.rethrowUnexpectedError()`. Add custom error handling.

### DIFF
--- a/src/ckeditorerror.js
+++ b/src/ckeditorerror.js
@@ -91,6 +91,38 @@ export default class CKEditorError extends Error {
 	is( type ) {
 		return type === 'CKEditorError';
 	}
+
+	/**
+	 * A utility that ensures the the thrown error is a {@link utils/ckeditorerror~CKEditorError} one.
+	 * It is uesful when combined with the {@link watchdog/watchdog~Watchdog} feature, which can restart the editor in case
+	 * of a {@link utils/ckeditorerror~CKEditorError} error.
+	 *
+	 * @param {Error} err An error.
+	 * @param {Object} context An object conected through properties with the editor instance. This context will be used
+	 * by the watchdog to verify which editor should be restarted.
+	 */
+	static rethrowUnexpectedError( err, context ) {
+		if ( err.is && err.is( 'CKEditorError' ) ) {
+			throw err;
+		}
+
+		/**
+		 * An unexpected error occurred inside the CKEditor 5 codebase. The `error.data.originalError` property
+		 * shows the original error properties.
+		 *
+		 * This error is only useful when the editor is initialized using the {@link watchdog/watchdog~Watchdog} feature.
+		 * In case of such error (or any {@link utils/ckeditorerror~CKEditorError} error) the wathcdog should restart the editor.
+		 *
+		 * @error unexpected-error
+		 */
+		throw new CKEditorError( 'unexpected-error', context, {
+			originalError: {
+				message: err.message,
+				stack: err.stack,
+				name: err.name
+			}
+		} );
+	}
 }
 
 /**

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -13,6 +13,7 @@ import priorities from './priorities';
 
 // To check if component is loaded more than once.
 import './version';
+import CKEditorError from './ckeditorerror';
 
 const _listeningTo = Symbol( 'listeningTo' );
 const _emitterId = Symbol( 'emitterId' );
@@ -184,58 +185,62 @@ const EmitterMixin = {
 	 * @inheritDoc
 	 */
 	fire( eventOrInfo, ...args ) {
-		const eventInfo = eventOrInfo instanceof EventInfo ? eventOrInfo : new EventInfo( this, eventOrInfo );
-		const event = eventInfo.name;
-		let callbacks = getCallbacksForEvent( this, event );
+		try {
+			const eventInfo = eventOrInfo instanceof EventInfo ? eventOrInfo : new EventInfo( this, eventOrInfo );
+			const event = eventInfo.name;
+			let callbacks = getCallbacksForEvent( this, event );
 
-		// Record that the event passed this emitter on its path.
-		eventInfo.path.push( this );
+			// Record that the event passed this emitter on its path.
+			eventInfo.path.push( this );
 
-		// Handle event listener callbacks first.
-		if ( callbacks ) {
-			// Arguments passed to each callback.
-			const callbackArgs = [ eventInfo, ...args ];
+			// Handle event listener callbacks first.
+			if ( callbacks ) {
+				// Arguments passed to each callback.
+				const callbackArgs = [ eventInfo, ...args ];
 
-			// Copying callbacks array is the easiest and most secure way of preventing infinite loops, when event callbacks
-			// are added while processing other callbacks. Previous solution involved adding counters (unique ids) but
-			// failed if callbacks were added to the queue before currently processed callback.
-			// If this proves to be too inefficient, another method is to change `.on()` so callbacks are stored if same
-			// event is currently processed. Then, `.fire()` at the end, would have to add all stored events.
-			callbacks = Array.from( callbacks );
+				// Copying callbacks array is the easiest and most secure way of preventing infinite loops, when event callbacks
+				// are added while processing other callbacks. Previous solution involved adding counters (unique ids) but
+				// failed if callbacks were added to the queue before currently processed callback.
+				// If this proves to be too inefficient, another method is to change `.on()` so callbacks are stored if same
+				// event is currently processed. Then, `.fire()` at the end, would have to add all stored events.
+				callbacks = Array.from( callbacks );
 
-			for ( let i = 0; i < callbacks.length; i++ ) {
-				callbacks[ i ].callback.apply( this, callbackArgs );
+				for ( let i = 0; i < callbacks.length; i++ ) {
+					callbacks[ i ].callback.apply( this, callbackArgs );
 
-				// Remove the callback from future requests if off() has been called.
-				if ( eventInfo.off.called ) {
-					// Remove the called mark for the next calls.
-					delete eventInfo.off.called;
+					// Remove the callback from future requests if off() has been called.
+					if ( eventInfo.off.called ) {
+						// Remove the called mark for the next calls.
+						delete eventInfo.off.called;
 
-					removeCallback( this, event, callbacks[ i ].callback );
+						removeCallback( this, event, callbacks[ i ].callback );
+					}
+
+					// Do not execute next callbacks if stop() was called.
+					if ( eventInfo.stop.called ) {
+						break;
+					}
+				}
+			}
+
+			// Delegate event to other emitters if needed.
+			if ( this._delegations ) {
+				const destinations = this._delegations.get( event );
+				const passAllDestinations = this._delegations.get( '*' );
+
+				if ( destinations ) {
+					fireDelegatedEvents( destinations, eventInfo, args );
 				}
 
-				// Do not execute next callbacks if stop() was called.
-				if ( eventInfo.stop.called ) {
-					break;
+				if ( passAllDestinations ) {
+					fireDelegatedEvents( passAllDestinations, eventInfo, args );
 				}
 			}
+
+			return eventInfo.return;
+		} catch ( err ) {
+			CKEditorError.rethrowUnexpectedError( err, this );
 		}
-
-		// Delegate event to other emitters if needed.
-		if ( this._delegations ) {
-			const destinations = this._delegations.get( event );
-			const passAllDestinations = this._delegations.get( '*' );
-
-			if ( destinations ) {
-				fireDelegatedEvents( destinations, eventInfo, args );
-			}
-
-			if ( passAllDestinations ) {
-				fireDelegatedEvents( passAllDestinations, eventInfo, args );
-			}
-		}
-
-		return eventInfo.return;
 	},
 
 	/**

--- a/tests/ckeditorerror.js
+++ b/tests/ckeditorerror.js
@@ -4,6 +4,7 @@
  */
 
 import { default as CKEditorError, DOCUMENTATION_URL } from '../src/ckeditorerror';
+import { expectToThrowCKEditorError } from './_utils/utils';
 
 describe( 'CKEditorError', () => {
 	it( 'inherits from Error', () => {
@@ -86,6 +87,32 @@ describe( 'CKEditorError', () => {
 
 			expect( ( !!ckeditorError.is && ckeditorError.is( 'CKEditorError' ) ) ).to.be.true;
 			expect( ( !!regularError.is && regularError.is( 'CKEditorError' ) ) ).to.be.false;
+		} );
+	} );
+
+	describe( 'static rethrowUnexpectedError()', () => {
+		it( 'should rethrow the original CKEditorError as it is', () => {
+			const ckeditorError = new CKEditorError( 'foo', null );
+
+			expectToThrowCKEditorError( () => {
+				CKEditorError.rethrowUnexpectedError( ckeditorError, {} );
+			}, /foo/, null );
+		} );
+
+		it( 'should rethrow an unexpected error wrapped in CKEditorError', () => {
+			const error = new Error( 'foo' );
+			error.stack = 'bar';
+			const context = {};
+
+			expectToThrowCKEditorError( () => {
+				CKEditorError.rethrowUnexpectedError( error, context );
+			}, /unexpected-error/, context, {
+				originalError: {
+					message: 'foo',
+					stack: 'bar',
+					name: 'Error'
+				}
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Introduced the `CKEditorError.rethrowUnexpectedError()` helper. Added custom error handling for the `Emitter#fire()` function. Part of ckeditor/ckeditor5#1304.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
