### PR TITLE
json import webpack 5 compatible

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -9,9 +9,10 @@
 
 /* globals window, global */
 
-import { version } from 'ckeditor5/package.json';
+import CKEditorPackageConfig from 'ckeditor5/package.json';
 import CKEditorError from './ckeditorerror';
 
+const { version } = CKEditorPackageConfig;
 const windowOrGlobal = typeof window === 'object' ? window : global;
 
 if ( windowOrGlobal.CKEDITOR_VERSION ) {


### PR DESCRIPTION
Fix: Updated `version.js` to use the default import of the `package.json` file to retain compatibility with Webpack 5. Closes ckeditor/ckeditor5#5660

### Additional information
Backwards compatible change.

![webpack_warning](https://user-images.githubusercontent.com/27768115/67467896-4a8cbf80-f652-11e9-8e9d-797c8ffbd58d.png)
