### PR TITLE
Use other style in normalizeHtml tests.

### DIFF
--- a/tests/_utils-tests/normalizehtml.js
+++ b/tests/_utils-tests/normalizehtml.js
@@ -8,29 +8,29 @@ import normalizeHtml from '../../tests/_utils/normalizehtml';
 describe( 'utils', () => {
 	describe( 'normalizeHtml', () => {
 		it( 'should sort attributes', () => {
-			const actual = '<a style="border:1px" class="" href="file://"></a>';
-			const expected = '<a class="" href="file://" style="border:1px"></a>';
+			const actual = '<a style="padding:1px" class="" href="file://"></a>';
+			const expected = '<a class="" href="file://" style="padding:1px"></a>';
 
 			expect( normalizeHtml( actual ) ).to.equal( expected );
 		} );
 
 		it( 'should normalize styles', () => {
-			const actual = '<a style="border:1px"></a>';
-			const expected = '<a style="border:1px"></a>';
+			const actual = '<a style="padding:1px"></a>';
+			const expected = '<a style="padding:1px"></a>';
 
 			expect( normalizeHtml( actual ) ).to.equal( expected );
 		} );
 
 		it( 'should lowercase attributes', () => {
-			const actual = '<A CLASS="" HREF="file://" STYLE="border:1px"></A>';
-			const expected = '<a class="" href="file://" style="border:1px"></a>';
+			const actual = '<A CLASS="" HREF="file://" STYLE="padding:1px"></A>';
+			const expected = '<a class="" href="file://" style="padding:1px"></a>';
 
 			expect( normalizeHtml( actual ) ).to.equal( expected );
 		} );
 
 		it( 'should trim whitespace', () => {
-			const actual = '<a class="  " href="file://"      style="border:  1px"></a>';
-			const expected = '<a class="" href="file://" style="border:1px"></a>';
+			const actual = '<a class="  " href="file://"      style="padding:  1px"></a>';
+			const expected = '<a class="" href="file://" style="padding:1px"></a>';
 
 			expect( normalizeHtml( actual ) ).to.equal( expected );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Align tests to the changes in style normalization.

---

### Additional information

Sub-pr for: https://github.com/ckeditor/ckeditor5-engine/pull/1807.

* I've used safer `padding` style instead of the `border` which is output as `border-top, -right,`etc.
