### PR TITLE
Improve error rethrowing by replacing the error stack

### DIFF
--- a/src/ckeditorerror.js
+++ b/src/ckeditorerror.js
@@ -1,5 +1,3 @@
-/* globals console */
-
 /**
  * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
@@ -109,8 +107,8 @@ export default class CKEditorError extends Error {
 		}
 
 		/**
-		 * An unexpected error occurred inside the CKEditor 5 codebase. The `error.data.originalError` property
-		 * shows the original error properties.
+		 * An unexpected error occurred inside the CKEditor 5 codebase. This error will look like the original one
+		 * to make the debugging easier.
 		 *
 		 * This error is only useful when the editor is initialized using the {@link module:watchdog/watchdog~Watchdog} feature.
 		 * In case of such error (or any {@link module:utils/ckeditorerror~CKEditorError} error) the watchdog should restart the editor.
@@ -120,11 +118,8 @@ export default class CKEditorError extends Error {
 		const error = new CKEditorError( err.message, context );
 
 		// Restore the original stack trace to make the error look like the original one.
+		// See https://github.com/ckeditor/ckeditor5/issues/5595 for more details.
 		error.stack = err.stack;
-
-		console.log( err.stack );
-
-		console.log( err );
 
 		throw error;
 	}

--- a/src/ckeditorerror.js
+++ b/src/ckeditorerror.js
@@ -1,3 +1,5 @@
+/* globals console */
+
 /**
  * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
@@ -94,11 +96,11 @@ export default class CKEditorError extends Error {
 
 	/**
 	 * A utility that ensures the the thrown error is a {@link module:utils/ckeditorerror~CKEditorError} one.
-	 * It is uesful when combined with the {@link module:watchdog/watchdog~Watchdog} feature, which can restart the editor in case
+	 * It is useful when combined with the {@link module:watchdog/watchdog~Watchdog} feature, which can restart the editor in case
 	 * of a {@link module:utils/ckeditorerror~CKEditorError} error.
 	 *
 	 * @param {Error} err An error.
-	 * @param {Object} context An object conected through properties with the editor instance. This context will be used
+	 * @param {Object} context An object connected through properties with the editor instance. This context will be used
 	 * by the watchdog to verify which editor should be restarted.
 	 */
 	static rethrowUnexpectedError( err, context ) {
@@ -111,17 +113,20 @@ export default class CKEditorError extends Error {
 		 * shows the original error properties.
 		 *
 		 * This error is only useful when the editor is initialized using the {@link module:watchdog/watchdog~Watchdog} feature.
-		 * In case of such error (or any {@link module:utils/ckeditorerror~CKEditorError} error) the wathcdog should restart the editor.
+		 * In case of such error (or any {@link module:utils/ckeditorerror~CKEditorError} error) the watchdog should restart the editor.
 		 *
 		 * @error unexpected-error
 		 */
-		throw new CKEditorError( 'unexpected-error', context, {
-			originalError: {
-				message: err.message,
-				stack: err.stack,
-				name: err.name
-			}
-		} );
+		const error = new CKEditorError( err.message, context );
+
+		// Restore the original stack trace to make the error look like the original one.
+		error.stack = err.stack;
+
+		console.log( err.stack );
+
+		console.log( err );
+
+		throw error;
 	}
 }
 

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -239,6 +239,7 @@ const EmitterMixin = {
 
 			return eventInfo.return;
 		} catch ( err ) {
+			// @if CK_DEBUG // throw err;
 			CKEditorError.rethrowUnexpectedError( err, this );
 		}
 	},

--- a/src/emittermixin.js
+++ b/src/emittermixin.js
@@ -240,6 +240,7 @@ const EmitterMixin = {
 			return eventInfo.return;
 		} catch ( err ) {
 			// @if CK_DEBUG // throw err;
+			/* istanbul ignore next */
 			CKEditorError.rethrowUnexpectedError( err, this );
 		}
 	},

--- a/tests/ckeditorerror.js
+++ b/tests/ckeditorerror.js
@@ -106,13 +106,7 @@ describe( 'CKEditorError', () => {
 
 			expectToThrowCKEditorError( () => {
 				CKEditorError.rethrowUnexpectedError( error, context );
-			}, /unexpected-error/, context, {
-				originalError: {
-					message: 'foo',
-					stack: 'bar',
-					name: 'Error'
-				}
-			} );
+			}, /foo/, context );
 		} );
 	} );
 } );

--- a/tests/emittermixin.js
+++ b/tests/emittermixin.js
@@ -167,7 +167,7 @@ describe( 'EmitterMixin', () => {
 		} );
 
 		it( 'should wrap an error into the CKEditorError if a native error was thrown', () => {
-			const error = new Error( 'foo' );
+			const error = new TypeError( 'foo' );
 			error.stack = 'bar';
 
 			emitter.on( 'test', () => {
@@ -176,13 +176,7 @@ describe( 'EmitterMixin', () => {
 
 			expectToThrowCKEditorError( () => {
 				emitter.fire( 'test' );
-			}, /unexpected-error/, emitter, {
-				originalError: {
-					message: 'foo',
-					stack: 'bar',
-					name: 'Error'
-				}
-			} );
+			}, /bar/ );
 		} );
 
 		describe( 'return value', () => {
@@ -191,7 +185,7 @@ describe( 'EmitterMixin', () => {
 			} );
 
 			it( 'is undefined if none of the listeners modified EventInfo#return', () => {
-				emitter.on( 'foo', () => {} );
+				emitter.on( 'foo', () => { } );
 
 				expect( emitter.fire( 'foo' ) ).to.be.undefined;
 			} );
@@ -422,8 +416,8 @@ describe( 'EmitterMixin', () => {
 		} );
 
 		it( 'should not fail with unknown events', () => {
-			emitter.off( 'foo', () => {} );
-			emitter.off( 'foo:bar', () => {} );
+			emitter.off( 'foo', () => { } );
+			emitter.off( 'foo:bar', () => { } );
 
 			emitter.off( 'foo' );
 			emitter.off( 'foo:bar' );
@@ -707,17 +701,17 @@ describe( 'EmitterMixin', () => {
 		} );
 
 		it( 'should not fail with unknown events', () => {
-			listener.stopListening( emitter, 'foo', () => {} );
-			listener.stopListening( emitter, 'foo:bar', () => {} );
+			listener.stopListening( emitter, 'foo', () => { } );
+			listener.stopListening( emitter, 'foo:bar', () => { } );
 			listener.stopListening( emitter, 'foo' );
 			listener.stopListening( emitter, 'foo:bar' );
 		} );
 
 		it( 'should not fail with unknown emitter', () => {
-			listener.listenTo( emitter, 'foo:bar', () => {} );
+			listener.listenTo( emitter, 'foo:bar', () => { } );
 
-			listener.stopListening( {}, 'foo', () => {} );
-			listener.stopListening( {}, 'foo:bar', () => {} );
+			listener.stopListening( {}, 'foo', () => { } );
+			listener.stopListening( {}, 'foo:bar', () => { } );
 			listener.stopListening( {}, 'foo' );
 			listener.stopListening( {}, 'foo:bar' );
 			listener.stopListening( {} );
@@ -727,7 +721,7 @@ describe( 'EmitterMixin', () => {
 			const spy = sinon.spy();
 
 			listener.listenTo( emitter, 'foo', spy );
-			listener.stopListening( emitter, 'foo', () => {} );
+			listener.stopListening( emitter, 'foo', () => { } );
 
 			emitter.fire( 'foo' );
 
@@ -1347,7 +1341,7 @@ describe( '_getEmitterListenedTo', () => {
 	} );
 
 	it( 'should return emitter with given id', () => {
-		listener.listenTo( emitter, 'eventName', () => {} );
+		listener.listenTo( emitter, 'eventName', () => { } );
 		const emitterId = _getEmitterId( emitter );
 
 		expect( _getEmitterListenedTo( listener, emitterId ) ).to.equal( emitter );

--- a/tests/emittermixin.js
+++ b/tests/emittermixin.js
@@ -185,7 +185,7 @@ describe( 'EmitterMixin', () => {
 			} );
 
 			it( 'is undefined if none of the listeners modified EventInfo#return', () => {
-				emitter.on( 'foo', () => { } );
+				emitter.on( 'foo', () => {} );
 
 				expect( emitter.fire( 'foo' ) ).to.be.undefined;
 			} );
@@ -416,8 +416,8 @@ describe( 'EmitterMixin', () => {
 		} );
 
 		it( 'should not fail with unknown events', () => {
-			emitter.off( 'foo', () => { } );
-			emitter.off( 'foo:bar', () => { } );
+			emitter.off( 'foo', () => {} );
+			emitter.off( 'foo:bar', () => {} );
 
 			emitter.off( 'foo' );
 			emitter.off( 'foo:bar' );
@@ -701,17 +701,17 @@ describe( 'EmitterMixin', () => {
 		} );
 
 		it( 'should not fail with unknown events', () => {
-			listener.stopListening( emitter, 'foo', () => { } );
-			listener.stopListening( emitter, 'foo:bar', () => { } );
+			listener.stopListening( emitter, 'foo', () => {} );
+			listener.stopListening( emitter, 'foo:bar', () => {} );
 			listener.stopListening( emitter, 'foo' );
 			listener.stopListening( emitter, 'foo:bar' );
 		} );
 
 		it( 'should not fail with unknown emitter', () => {
-			listener.listenTo( emitter, 'foo:bar', () => { } );
+			listener.listenTo( emitter, 'foo:bar', () => {} );
 
-			listener.stopListening( {}, 'foo', () => { } );
-			listener.stopListening( {}, 'foo:bar', () => { } );
+			listener.stopListening( {}, 'foo', () => {} );
+			listener.stopListening( {}, 'foo:bar', () => {} );
 			listener.stopListening( {}, 'foo' );
 			listener.stopListening( {}, 'foo:bar' );
 			listener.stopListening( {} );
@@ -721,7 +721,7 @@ describe( 'EmitterMixin', () => {
 			const spy = sinon.spy();
 
 			listener.listenTo( emitter, 'foo', spy );
-			listener.stopListening( emitter, 'foo', () => { } );
+			listener.stopListening( emitter, 'foo', () => {} );
 
 			emitter.fire( 'foo' );
 
@@ -1341,7 +1341,7 @@ describe( '_getEmitterListenedTo', () => {
 	} );
 
 	it( 'should return emitter with given id', () => {
-		listener.listenTo( emitter, 'eventName', () => { } );
+		listener.listenTo( emitter, 'eventName', () => {} );
 		const emitterId = _getEmitterId( emitter );
 
 		expect( _getEmitterListenedTo( listener, emitterId ) ).to.equal( emitter );

--- a/tests/emittermixin.js
+++ b/tests/emittermixin.js
@@ -166,17 +166,16 @@ describe( 'EmitterMixin', () => {
 			}, /Foo/, null );
 		} );
 
-		it( 'should wrap an error into the CKEditorError if a native error was thrown', () => {
+		it( 'should rethrow the native errors as they are in the dubug=true mode', () => {
 			const error = new TypeError( 'foo' );
-			error.stack = 'bar';
 
 			emitter.on( 'test', () => {
 				throw error;
 			} );
 
-			expectToThrowCKEditorError( () => {
+			expect( () => {
 				emitter.fire( 'test' );
-			}, /foo/ );
+			} ).to.throw( TypeError, /foo/ );
 		} );
 
 		describe( 'return value', () => {

--- a/tests/emittermixin.js
+++ b/tests/emittermixin.js
@@ -176,7 +176,7 @@ describe( 'EmitterMixin', () => {
 
 			expectToThrowCKEditorError( () => {
 				emitter.fire( 'test' );
-			}, /bar/ );
+			}, /foo/ );
 		} );
 
 		describe( 'return value', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Improved error rethrowing by replacing the error stack. Closes ckeditor/ckeditor5#5595.

---

### Additional information

Requires:
- https://github.com/ckeditor/ckeditor5-engine/pull/1810
- https://github.com/ckeditor/ckeditor5-core/pull/202
- https://github.com/ckeditor/ckeditor5-image/pull/336
- https://github.com/ckeditor/ckeditor5-watchdog/pull/30