### PR TITLE
Added iterator interface to the Config class.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -114,14 +114,14 @@ export default class Config {
 	}
 
 	/**
-	 * Iterable interface.
-	 *
 	 * Iterates over all top level configuration names.
 	 *
 	 * @returns {Iterable.<String>}
 	 */
-	[ Symbol.iterator ]() {
-		return Object.keys( this._config )[ Symbol.iterator ]();
+	* names() {
+		for ( const name of Object.keys( this._config ) ) {
+			yield name;
+		}
 	}
 
 	/**

--- a/src/config.js
+++ b/src/config.js
@@ -114,6 +114,17 @@ export default class Config {
 	}
 
 	/**
+	 * Iterable interface.
+	 *
+	 * Iterates over all top level configuration names.
+	 *
+	 * @returns {Iterable.<String>}
+	 */
+	[ Symbol.iterator ]() {
+		return Object.keys( this._config )[ Symbol.iterator ]();
+	}
+
+	/**
 	 * Saves passed configuration to the specified target (nested object).
 	 *
 	 * @private

--- a/tests/config.js
+++ b/tests/config.js
@@ -459,4 +459,10 @@ describe( 'Config', () => {
 			expect( nodesAgain ).to.deep.equal( nodes );
 		} );
 	} );
+
+	describe( 'iterator', () => {
+		it( 'should return top level keys of the configuration', () => {
+			expect( Array.from( config ) ).to.be.deep.equal( [ 'creator', 'language', 'resize', 'toolbar', 'options' ] );
+		} );
+	} );
 } );

--- a/tests/config.js
+++ b/tests/config.js
@@ -460,9 +460,9 @@ describe( 'Config', () => {
 		} );
 	} );
 
-	describe( 'iterator', () => {
-		it( 'should return top level keys of the configuration', () => {
-			expect( Array.from( config ) ).to.be.deep.equal( [ 'creator', 'language', 'resize', 'toolbar', 'options' ] );
+	describe( 'names()', () => {
+		it( 'should return an iterator of top level names of the configuration', () => {
+			expect( Array.from( config.names() ) ).to.be.deep.equal( [ 'creator', 'language', 'resize', 'toolbar', 'options' ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added iterator interface to the `Config` class. Part of ckeditor/ckeditor5#5891.

---

### Additional information

Required by the https://github.com/ckeditor/ckeditor5-core/pull/204. `Editor#config` needs to be extended by the `Context#config`.
