### PR TITLE
Used a cheaper type check in toMap function, to improve performance

### DIFF
--- a/src/objecttomap.js
+++ b/src/objecttomap.js
@@ -13,6 +13,8 @@
  *		const map = objectToMap( { 'foo': 1, 'bar': 2 } );
  *		map.get( 'foo' ); // 1
  *
+ * **Note**: For mixed data (`Object` or `Iterable`) there's a dedicated {@link module:utils/tomap~toMap} function.
+ *
  * @param {Object} obj Object to transform.
  * @returns {Map} Map created from object.
  */

--- a/src/tomap.js
+++ b/src/tomap.js
@@ -8,7 +8,7 @@
  */
 
 import objectToMap from './objecttomap';
-import { isPlainObject } from 'lodash-es';
+import isIterable from './isiterable';
 
 /**
  * Transforms object or iterable to map. Iterable needs to be in the format acceptable by the `Map` constructor.
@@ -21,9 +21,9 @@ import { isPlainObject } from 'lodash-es';
  * @returns {Map} Map created from data.
  */
 export default function toMap( data ) {
-	if ( isPlainObject( data ) ) {
-		return objectToMap( data );
-	} else {
+	if ( isIterable( data ) ) {
 		return new Map( data );
+	} else {
+		return objectToMap( data );
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Improved `toMap` method performance. This results with improved editor data processing speed. Closes ckeditor/ckeditor5#5854.

---

### Additional information

lodash' `isPlainObject` is a pretty performance expensive function, so should be avoided in places that are called frequently. This PR reverses the condition so a cheaper and more common condition is used first.

Alternatively we could create our own, more optimized `isPlainObject` implementation, but since our code uses iterables for the most part here, it's enough to just reverse the condition check.

You can use manual tests added in ckeditor/ckeditor5#5880 to have use performance tests.

There's a sub pr for this: ckeditor/ckeditor5-engine#1822.

### Overview

#### tl;dr

| test case | total time (ms/%) | PR total time (ms/%) | total click handler time | PR total click handler time |
| --- | --- | --- | --- | --- |
| [rich editor setData](http://localhost:8125/ckeditor5/tests/manual/performance/richeditor.html) small content | 7.6ms / 5.7% | 0.5ms / 0.4% | 131.92ms | 129.39ms (Reduced by ~1.92%) |
| rich editor setData medium content | 805.4ms / 16.2% | 21.4ms / 0.5% | 4.99s | 4.02s (reduced by ~19.4%) |
| [performance/setdata](http://localhost:8125/ckeditor5/tests/manual/performance/setdata.html) full websites (styled) | 632.2ms / 13.7% | 20.7ms / 0.5% | 4.23s | 3.55s (reduced by ~%16) |

#### RichEditor (short semantic setData)

Before:

![](https://user-images.githubusercontent.com/5353898/73852944-5763a680-4830-11ea-8ff0-0c400f5ad8c1.png)

After:

![](https://user-images.githubusercontent.com/5353898/73854967-a3fcb100-4833-11ea-854c-e30754110954.png)

#### RichEditor (medium semantic setData)

Before:

![](https://user-images.githubusercontent.com/5353898/73852859-2edbac80-4830-11ea-9df4-440ad339c2b4.png)

After:

![](https://user-images.githubusercontent.com/5353898/73853088-92fe7080-4830-11ea-95f9-29dedd97df82.png)

#### [setData](http://localhost:8125/ckeditor5/tests/manual/performance/setdata.html) (full websites)

Before:

![](https://user-images.githubusercontent.com/5353898/73856007-23d74b00-4835-11ea-948e-d5c6a97a7a32.png)

After:

![](https://user-images.githubusercontent.com/5353898/73856056-33569400-4835-11ea-8293-26d1f49c7d48.png)