### PR TITLE
Introduced copying default configuration in the `Config` class to make the watchdog feature work correctly

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -30,7 +30,9 @@ export default class Config {
 
 		// Set default configuration.
 		if ( defaultConfigurations ) {
-			this.define( defaultConfigurations );
+			// Clone the configuration to make sure that the properties will not be shared
+			// between editors and make the watchdog feature work correctly.
+			this.define( cloneConfig( defaultConfigurations ) );
 		}
 
 		// Set initial configuration.
@@ -234,7 +236,7 @@ function cloneConfig( source ) {
 	return cloneDeepWith( source, leaveDOMReferences );
 }
 
-// A customizer function for cloneDeepWith.
+// A customized function for cloneDeepWith.
 // It will leave references to DOM Elements instead of cloning them.
 //
 // @param {*} value

--- a/tests/config.js
+++ b/tests/config.js
@@ -6,6 +6,7 @@
 /* global document */
 
 import Config from '../src/config';
+import areConnectedThroughProperties from '../src/areconnectedthroughproperties';
 
 describe( 'Config', () => {
 	let config;
@@ -61,6 +62,25 @@ describe( 'Config', () => {
 
 			expect( config.get( 'foo' ) ).to.equal( 1 );
 			expect( config.get( 'bar' ) ).to.equal( 2 );
+		} );
+
+		it( 'should copy default configuration to not share properties between config instances [watchdog]', () => {
+			const defaultConfig = {
+				foo: 1,
+				bar: [
+					/some regex/,
+					{
+						baz: {}
+					}
+				]
+			};
+
+			const config1 = new Config( {}, defaultConfig );
+			const config2 = new Config( {}, defaultConfig );
+
+			const areStructuresConnected = areConnectedThroughProperties( config1, config2 );
+
+			expect( areStructuresConnected ).to.be.false;
 		} );
 
 		it( 'passed parameters should override default parameters', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Introduced copying default configuration in the `Config` class to make the watchdog feature work correctly. Part of ckeditor/ckeditor5#6219.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
