### PR TITLE
Added support for initializing Collection using a constructor

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -128,7 +128,7 @@ export default class Collection {
 		if ( hasInitialItems ) {
 			for ( const item of initialItemsOrOptions ) {
 				this._items.push( item );
-				this._itemMap.set( this._getItemId( item ), item );
+				this._itemMap.set( this._getItemIdBeforeAdding( item ), item );
 			}
 		}
 
@@ -657,7 +657,7 @@ export default class Collection {
 	 * @param {Object} item Item to be added.
 	 * @returns {String}
 	 */
-	_getItemId( item ) {
+	_getItemIdBeforeAdding( item ) {
 		const idProperty = this._idProperty;
 		let itemId;
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -54,6 +54,7 @@ export default class Collection {
 	 *		const nonEmptyCollection = new Collection( [ { name: 'John' } ], { idProperty: 'name' } );
 	 *		nonEmptyCollection.add( { name: 'George' } );
 	 *		console.log( collection.get( 'George' ) ); // -> { name: 'George' }
+	 *		console.log( collection.get( 'John' ) ); // -> { name: 'John' }
 	 *
 	 * @param {Iterable.<Object>|Object} initialItemsOrOptions The initial items of the collection or
 	 * the options object.

--- a/src/collection.js
+++ b/src/collection.js
@@ -128,7 +128,7 @@ export default class Collection {
 		if ( hasInitialItems ) {
 			for ( const item of initialItemsOrOptions ) {
 				this._items.push( item );
-				this._itemMap.set( this._getItemIdBeforeAdding( item ), item );
+				this._itemMap.set( this._getItemId( item ), item );
 			}
 		}
 
@@ -648,7 +648,16 @@ export default class Collection {
 		} );
 	}
 
-	_getItemIdBeforeAdding( item ) {
+	/**
+	 * Returns an unique id property for a given `item`.
+	 *
+	 * The method will generate new id and assign it to the `item` if it doesn't have any.
+	 *
+	 * @private
+	 * @param {Object} item Item to be added.
+	 * @returns {String}
+	 */
+	_getItemId( item ) {
 		const idProperty = this._idProperty;
 		let itemId;
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -10,6 +10,7 @@
 import EmitterMixin from './emittermixin';
 import CKEditorError from './ckeditorerror';
 import uid from './uid';
+import isIterable from './isiterable';
 import mix from './mix';
 
 /**
@@ -54,14 +55,14 @@ export default class Collection {
 	 *		nonEmptyCollection.add( { name: 'George' } );
 	 *		console.log( collection.get( 'George' ) ); // -> { name: 'George' }
 	 *
-	 * @param {Array.<Object>|Object} initialItemsOrOptions The initial items of the collection or
+	 * @param {Iterable.<Object>|Object} initialItemsOrOptions The initial items of the collection or
 	 * the options object.
 	 * @param {Object} [options={}] The options object, when the first argument is an array of initial items.
 	 * @param {String} [options.idProperty='id'] The name of the property which is used to identify an item.
 	 * Items that do not have such a property will be assigned one when added to the collection.
 	 */
 	constructor( initialItemsOrOptions = {}, options = {} ) {
-		const hasInitialItems = initialItemsOrOptions instanceof Array;
+		const hasInitialItems = isIterable( initialItemsOrOptions );
 
 		if ( !hasInitialItems ) {
 			options = initialItemsOrOptions;

--- a/src/collection.js
+++ b/src/collection.js
@@ -29,7 +29,7 @@ export default class Collection {
 	/**
 	 * Creates a new Collection instance.
 	 *
-	 * You can provide an array of initial items the collection will be created with:
+	 * You can provide an iterable of initial items the collection will be created with:
 	 *
 	 *		const collection = new Collection( [ { id: 'John' }, { id: 'Mike' } ] );
 	 *

--- a/src/collection.js
+++ b/src/collection.js
@@ -180,32 +180,7 @@ export default class Collection {
 	 * @fires add
 	 */
 	add( item, index ) {
-		let itemId;
-		const idProperty = this._idProperty;
-
-		if ( ( idProperty in item ) ) {
-			itemId = item[ idProperty ];
-
-			if ( typeof itemId != 'string' ) {
-				/**
-				 * This item's id should be a string.
-				 *
-				 * @error collection-add-invalid-id
-				 */
-				throw new CKEditorError( 'collection-add-invalid-id', this );
-			}
-
-			if ( this.get( itemId ) ) {
-				/**
-				 * This item already exists in the collection.
-				 *
-				 * @error collection-add-item-already-exists
-				 */
-				throw new CKEditorError( 'collection-add-item-already-exists', this );
-			}
-		} else {
-			item[ idProperty ] = itemId = uid();
-		}
+		const itemId = this._getItemIdBeforeAdding( item );
 
 		// TODO: Use ES6 default function argument.
 		if ( index === undefined ) {
@@ -669,13 +644,8 @@ export default class Collection {
 				 * This item's id should be a string.
 				 *
 				 * @error collection-add-invalid-id
-				 * @param {Object} item The item being added to the collection.
-				 * @param {module:utils/collection~Collection} collection The collection the item is added to.
 				 */
-				throw new CKEditorError( 'collection-add-invalid-id', {
-					item,
-					collection: this,
-				} );
+				throw new CKEditorError( 'collection-add-invalid-id', this );
 			}
 
 			if ( this.get( itemId ) ) {
@@ -683,13 +653,8 @@ export default class Collection {
 				 * This item already exists in the collection.
 				 *
 				 * @error collection-add-item-already-exists
-				 * @param {Object} item The item being added to the collection.
-				 * @param {module:utils/collection~Collection} collection The collection the item is added to.
 				 */
-				throw new CKEditorError( 'collection-add-item-already-exists', {
-					item,
-					collection: this
-				} );
+				throw new CKEditorError( 'collection-add-item-already-exists', this );
 			}
 		} else {
 			item[ idProperty ] = itemId = uid();

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -26,7 +26,7 @@ describe( 'Collection', () => {
 
 	describe( 'constructor()', () => {
 		describe( 'setting initial collection items', () => {
-			it( 'works using an array', () => {
+			it( 'should work using an array', () => {
 				const item1 = getItem( 'foo' );
 				const item2 = getItem( 'bar' );
 				const collection = new Collection( [ item1, item2 ] );

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -25,18 +25,44 @@ describe( 'Collection', () => {
 	} );
 
 	describe( 'constructor()', () => {
-		it( 'allows to change the id property used by the collection', () => {
-			const item1 = { id: 'foo', name: 'xx' };
-			const item2 = { id: 'foo', name: 'yy' };
-			const collection = new Collection( { idProperty: 'name' } );
-
-			collection.add( item1 );
-			collection.add( item2 );
+		it( 'allows setting initial collection items', () => {
+			const item1 = getItem( 'foo' );
+			const item2 = getItem( 'bar' );
+			const collection = new Collection( [ item1, item2 ] );
 
 			expect( collection ).to.have.length( 2 );
 
-			expect( collection.get( 'xx' ) ).to.equal( item1 );
-			expect( collection.remove( 'yy' ) ).to.equal( item2 );
+			expect( collection.get( 0 ) ).to.equal( item1 );
+			expect( collection.get( 1 ) ).to.equal( item2 );
+			expect( collection.get( 'foo' ) ).to.equal( item1 );
+			expect( collection.get( 'bar' ) ).to.equal( item2 );
+		} );
+
+		describe( 'options', () => {
+			it( 'allow to change the id property used by the collection', () => {
+				const item1 = { id: 'foo', name: 'xx' };
+				const item2 = { id: 'foo', name: 'yy' };
+				const collection = new Collection( { idProperty: 'name' } );
+
+				collection.add( item1 );
+				collection.add( item2 );
+
+				expect( collection ).to.have.length( 2 );
+
+				expect( collection.get( 'xx' ) ).to.equal( item1 );
+				expect( collection.remove( 'yy' ) ).to.equal( item2 );
+			} );
+
+			it( 'allow to change the id property used by the collection (initial items)', () => {
+				const item1 = { id: 'foo', name: 'xx' };
+				const item2 = { id: 'foo', name: 'yy' };
+				const collection = new Collection( [ item1, item2 ], { idProperty: 'name' } );
+
+				expect( collection ).to.have.length( 2 );
+
+				expect( collection.get( 'xx' ) ).to.equal( item1 );
+				expect( collection.remove( 'yy' ) ).to.equal( item2 );
+			} );
 		} );
 	} );
 

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -92,7 +92,7 @@ describe( 'Collection', () => {
 				expect( collection.remove( 'yy' ) ).to.equal( item2 );
 			} );
 
-			it( 'allow to change the id property used by the collection (initial items)', () => {
+			it( 'should allow to change the id property used by the collection (initial items passed to the constructor)', () => {
 				const item1 = { id: 'foo', name: 'xx' };
 				const item2 = { id: 'foo', name: 'yy' };
 				const collection = new Collection( [ item1, item2 ], { idProperty: 'name' } );

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -50,6 +50,31 @@ describe( 'Collection', () => {
 				expect( collection.get( 0 ) ).to.equal( item1 );
 				expect( collection.get( 1 ) ).to.equal( item2 );
 			} );
+
+			it( 'generates id for items that doesn\'t have it', () => {
+				const item = {};
+				const collection = new Collection( [ item ] );
+
+				expect( collection.get( 0 ).id ).to.be.a( 'string' );
+				expect( collection.get( 0 ).id ).not.to.be.empty;
+			} );
+
+			it( 'throws an error when invalid item key is provided', () => {
+				const badIdItem = getItem( 1 ); // Number id is not supported.
+
+				expectToThrowCKEditorError( () => {
+					return new Collection( [ badIdItem ] );
+				}, /^collection-add-invalid-id/ );
+			} );
+
+			it( 'throws an error when items have a duplicated key', () => {
+				const item1 = getItem( 'foo' );
+				const item2 = getItem( 'foo' );
+
+				expectToThrowCKEditorError( () => {
+					return new Collection( [ item1, item2 ] );
+				}, /^collection-add-item-already-exists/ );
+			} );
 		} );
 
 		describe( 'options', () => {

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -25,17 +25,31 @@ describe( 'Collection', () => {
 	} );
 
 	describe( 'constructor()', () => {
-		it( 'allows setting initial collection items', () => {
-			const item1 = getItem( 'foo' );
-			const item2 = getItem( 'bar' );
-			const collection = new Collection( [ item1, item2 ] );
+		describe( 'setting initial collection items', () => {
+			it( 'works using an array', () => {
+				const item1 = getItem( 'foo' );
+				const item2 = getItem( 'bar' );
+				const collection = new Collection( [ item1, item2 ] );
 
-			expect( collection ).to.have.length( 2 );
+				expect( collection ).to.have.length( 2 );
 
-			expect( collection.get( 0 ) ).to.equal( item1 );
-			expect( collection.get( 1 ) ).to.equal( item2 );
-			expect( collection.get( 'foo' ) ).to.equal( item1 );
-			expect( collection.get( 'bar' ) ).to.equal( item2 );
+				expect( collection.get( 0 ) ).to.equal( item1 );
+				expect( collection.get( 1 ) ).to.equal( item2 );
+				expect( collection.get( 'foo' ) ).to.equal( item1 );
+				expect( collection.get( 'bar' ) ).to.equal( item2 );
+			} );
+
+			it( 'works using an iterable', () => {
+				const item1 = getItem( 'foo' );
+				const item2 = getItem( 'bar' );
+				const itemsSet = new Set( [ item1, item2 ] );
+				const collection = new Collection( itemsSet );
+
+				expect( collection ).to.have.length( 2 );
+
+				expect( collection.get( 0 ) ).to.equal( item1 );
+				expect( collection.get( 1 ) ).to.equal( item2 );
+			} );
 		} );
 
 		describe( 'options', () => {

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -39,7 +39,7 @@ describe( 'Collection', () => {
 				expect( collection.get( 'bar' ) ).to.equal( item2 );
 			} );
 
-			it( 'works using an iterable', () => {
+			it( 'should work using an iterable', () => {
 				const item1 = getItem( 'foo' );
 				const item2 = getItem( 'bar' );
 				const itemsSet = new Set( [ item1, item2 ] );
@@ -51,7 +51,7 @@ describe( 'Collection', () => {
 				expect( collection.get( 1 ) ).to.equal( item2 );
 			} );
 
-			it( 'generates id for items that doesn\'t have it', () => {
+			it( 'should generate ids for items that doesn\'t have it', () => {
 				const item = {};
 				const collection = new Collection( [ item ] );
 
@@ -59,7 +59,7 @@ describe( 'Collection', () => {
 				expect( collection.get( 0 ).id ).not.to.be.empty;
 			} );
 
-			it( 'throws an error when invalid item key is provided', () => {
+			it( 'should throw an error when an invalid item key is provided', () => {
 				const badIdItem = getItem( 1 ); // Number id is not supported.
 
 				expectToThrowCKEditorError( () => {
@@ -67,7 +67,7 @@ describe( 'Collection', () => {
 				}, /^collection-add-invalid-id/ );
 			} );
 
-			it( 'throws an error when items have a duplicated key', () => {
+			it( 'should throw an error when two items have the same key', () => {
 				const item1 = getItem( 'foo' );
 				const item2 = getItem( 'foo' );
 
@@ -78,7 +78,7 @@ describe( 'Collection', () => {
 		} );
 
 		describe( 'options', () => {
-			it( 'allow to change the id property used by the collection', () => {
+			it( 'should allow to change the id property used by the collection', () => {
 				const item1 = { id: 'foo', name: 'xx' };
 				const item2 = { id: 'foo', name: 'yy' };
 				const collection = new Collection( { idProperty: 'name' } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added support for initializing `Collection` items using a constructor. Closes ckeditor/ckeditor5#6319.

---

### Additional information

This PR was mostly based on #309 with some notable changes:

*   Reverted `collection-add-invalid-id` and `collection-add-item-already-exists` error interfaces back to what we have on the `master` branch (see [current](6f51d49026045ef9919cccab68eeeee736c4c7ac) vs [originally proposed](https://github.com/ckeditor/ckeditor5-utils/blob/1aac49db1ca9ea914f9fc44f00e295474faf3ed2/src/collection.js#L669-L693)). I don't think there's a strong reason to change this API.
*   `add()` remains unchanged with exception of reusing `_getItemIdBeforeAdding()`.
*   Added API docs.
*   Added couple more test cases: `generates id for items that doesn\'t have it`, `throws an error when invalid item key is provided`, `throws an error when items have a duplicated key`.

I had some doubts:

*   I wonder whether it would be better to do the item initialization as `options.items` instead of [adding `initialItemsOrOptions` next to `options`](https://github.com/ckeditor/ckeditor5-utils/blob/58bd45bcee5384f0e217f66063a1d5bc58eb5ce2/src/collection.js#L64). I believe any `xOrY` kind of variables are confusing for the API consumer.

Once this PR is merged, the `master` branch should get merged to the [#309](https://github.com/ckeditor/ckeditor5-utils/pull/309) PR so that the diff will get smaller and easier to review.

There's a subpr: ckeditor/ckeditor5-ui#545