### PR TITLE
i/6087: Linked to the "Deep dive into focus tracking" from the FocusTracker class docs

### DIFF
--- a/src/focustracker.js
+++ b/src/focustracker.js
@@ -24,6 +24,8 @@ import mix from './mix';
  * which contain other `focusable` elements. But note that this wrapper element has to be focusable too
  * (have e.g. `tabindex="-1"`).
  *
+ * Check out the {@glink framework/guides/deep-dive/focus-tracking "Deep dive into focus tracking" guide} to learn more.
+ *
  * @mixes module:utils/dom/emittermixin~EmitterMixin
  * @mixes module:utils/observablemixin~ObservableMixin
  */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Linked to the "Deep dive into focus tracking" from the FocusTracker class docs (see ckeditor/ckeditor5#6087).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5-ui/pull/552.
