### PR TITLE
i/6573: The `getPositionedAncestor()` helper should use `offsetParent` instead of `getComputedStyle()`

### DIFF
--- a/src/dom/getpositionedancestor.js
+++ b/src/dom/getpositionedancestor.js
@@ -16,29 +16,13 @@ import global from './global';
  * @returns {HTMLElement|null}
  */
 export default function getPositionedAncestor( element ) {
-	while ( element && element.tagName.toLowerCase() != 'html' ) {
-		if ( global.window.getComputedStyle( element ).position != 'static' ) {
-			return element;
-		}
-
-		element = element.parentElement;
+	if ( !element || !element.parentNode ) {
+		return null;
 	}
 
-	return null;
+	if ( element.offsetParent === global.document.body ) {
+		return null;
+	}
+
+	return element.offsetParent;
 }
-
-// export default function getPositionedAncestor( element ) {
-// 	if ( !element || !element.parentNode ) {
-// 		return null;
-// 	}
-
-// 	if ( element.style.position && element.style.position !== 'static' ) {
-// 		return element;
-// 	}
-
-// 	if ( element.offsetParent === global.document.body ) {
-// 		return null;
-// 	}
-
-// 	return element.offsetParent;
-// }

--- a/src/dom/getpositionedancestor.js
+++ b/src/dom/getpositionedancestor.js
@@ -26,3 +26,19 @@ export default function getPositionedAncestor( element ) {
 
 	return null;
 }
+
+// export default function getPositionedAncestor( element ) {
+// 	if ( !element || !element.parentNode ) {
+// 		return null;
+// 	}
+
+// 	if ( element.style.position && element.style.position !== 'static' ) {
+// 		return element;
+// 	}
+
+// 	if ( element.offsetParent === global.document.body ) {
+// 		return null;
+// 	}
+
+// 	return element.offsetParent;
+// }

--- a/src/dom/position.js
+++ b/src/dom/position.js
@@ -90,7 +90,7 @@ export function getOptimalPosition( { element, target, positions, limiter, fitIn
 		limiter = limiter();
 	}
 
-	const positionedElementAncestor = getPositionedAncestor( element.parentElement );
+	const positionedElementAncestor = getPositionedAncestor( element );
 	const elementRect = new Rect( element );
 	const targetRect = new Rect( target );
 

--- a/tests/dom/getpositionedancestor.js
+++ b/tests/dom/getpositionedancestor.js
@@ -24,14 +24,14 @@ describe( 'getPositionedAncestor', () => {
 		expect( getPositionedAncestor() ).to.be.null;
 	} );
 
-	it( 'should return null when there is no parent', () => {
+	it( 'should return null when there is no positioned ancestor', () => {
 		expect( getPositionedAncestor( element ) ).to.be.null;
 	} );
 
-	it( 'should consider passed element', () => {
+	it( 'should not consider the passed element', () => {
 		element.style.position = 'relative';
 
-		expect( getPositionedAncestor( element ) ).to.equal( element );
+		expect( getPositionedAncestor( element ) ).to.be.null;
 	} );
 
 	it( 'should find the positioned ancestor (direct parent)', () => {

--- a/tests/dom/position.js
+++ b/tests/dom/position.js
@@ -237,20 +237,19 @@ describe( 'getOptimalPosition()', () => {
 				}, {
 					position: 'absolute',
 					borderLeftWidth: '20px',
-					borderTopWidth: '40px'
+					borderTopWidth: '40px',
+					overflow: 'scroll',
+					width: '10px',
+					height: '10px',
+					background: 'red'
 				} );
 
 				Object.assign( element.style, {
 					width: '20px',
 					height: '20px',
 					marginTop: '100px',
-					marginLeft: '200px'
-				} );
-
-				Object.assign( parent.style, {
-					overflow: 'scroll',
-					width: '10px',
-					height: '10px'
+					marginLeft: '200px',
+					background: 'green'
 				} );
 
 				parent.appendChild( element );
@@ -260,8 +259,8 @@ describe( 'getOptimalPosition()', () => {
 				parent.scrollTop = 100;
 
 				assertPosition( { element, target, positions: [ attachLeftBottom ] }, {
-					top: 160,
-					left: 260,
+					top: 200,
+					left: 280,
 					name: 'left-bottom'
 				} );
 			} );
@@ -696,7 +695,7 @@ function getElement( rect = {}, styles = {} ) {
 		styles.borderTopWidth = '0px';
 	}
 
-	window.getComputedStyle.withArgs( element ).returns( styles );
+	Object.assign( element.style, styles );
 
 	return element;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: The `getPositionedAncestor()` helper should use `offsetParent` instead of `getComputedStyle()` for performance reasons. Closes ckeditor/ckeditor5#6573.

MINOR BREAKING CHANGE: The `getPositionedAncestor()` helper will no longer return the passed element when it is positioned. 

---

### Additional information

**When closed, it must be followed by an update and a [merge](https://github.com/cksource/ckeditor5-comments/pull/187) in the comments plugin.**

**An important notice: The `getPositionedAncestor()` helper is used only by the `getOptimalPosition()` helper at this moment.**

OK, so here's what happened in this PR:

1. I used `offsetParent` instead of `getComputedStyle()`, which results in a massive performance gain. This is how old vs new implementation performs when executed 100 times on a DOM tree of 100 ancestors:

   <img width="335" alt="Screenshot 2020-04-10 at 09 30 02" src="https://user-images.githubusercontent.com/1099479/78973106-7d971280-7b0f-11ea-87f7-0f148d20ddaf.png">

   I think the responsiveness of the UI should benefit from it because `getOptimalPosition()` is called dozens of times, for instance, when you resize the viewport, to re-position UI balloons.

2. In the old implementation the helper also considered the passed element (e.g. if it had `position: absolute`). It was wrong on many levels:
   * It wasn't documented.
   * It contradicted the name of the helper.
   * We didn't benefit from that fact.

   Dropping this behaviour allowed me to get rid of `getComputedStyle()`. And things make sense now.

3. All changes made to `position.js` (`getOptimalPosition()`) and its tests are purely to move from mocked to real DOM elements. Using mocks no longer works when `getPositionedAncestor()` uses `offsetParent`.