### PR TITLE
Other: Remove `env.isEdge`. Closes ckeditor/ckeditor5#6202.

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -26,14 +26,6 @@ const env = {
 	isMac: isMac( userAgent ),
 
 	/**
-	 * Indicates that the application is running in Microsoft Edge.
-	 *
-	 * @static
-	 * @type {Boolean}
-	 */
-	isEdge: isEdge( userAgent ),
-
-	/**
 	 * Indicates that the application is running in Firefox (Gecko).
 	 *
 	 * @static
@@ -88,16 +80,6 @@ export function isMac( userAgent ) {
 }
 
 /**
- * Checks if User Agent represented by the string is Microsoft Edge.
- *
- * @param {String} userAgent **Lowercase** `navigator.userAgent` string.
- * @returns {Boolean} Whether User Agent is Edge or not.
- */
-export function isEdge( userAgent ) {
-	return !!userAgent.match( /edge\/(\d+.?\d*)/ );
-}
-
-/**
  * Checks if User Agent represented by the string is Firefox (Gecko).
  *
  * @param {String} userAgent **Lowercase** `navigator.userAgent` string.
@@ -137,7 +119,7 @@ export function isAndroid( userAgent ) {
 export function isRegExpUnicodePropertySupported() {
 	let isSupported = false;
 
-	// Feature detection for Unicode properties. Added in ES2018. Currently Firefox and Edge do not support it.
+	// Feature detection for Unicode properties. Added in ES2018. Currently Firefox does not support it.
 	// See https://github.com/ckeditor/ckeditor5-mention/issues/44#issuecomment-487002174.
 
 	try {

--- a/tests/env.js
+++ b/tests/env.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import env, { isEdge, isMac, isGecko, isSafari, isAndroid, isRegExpUnicodePropertySupported } from '../src/env';
+import env, { isMac, isGecko, isSafari, isAndroid, isRegExpUnicodePropertySupported } from '../src/env';
 
 function toLowerCase( str ) {
 	return str.toLowerCase();
@@ -17,12 +17,6 @@ describe( 'Env', () => {
 	describe( 'isMac', () => {
 		it( 'is a boolean', () => {
 			expect( env.isMac ).to.be.a( 'boolean' );
-		} );
-	} );
-
-	describe( 'isEdge', () => {
-		it( 'is a boolean', () => {
-			expect( env.isEdge ).to.be.a( 'boolean' );
 		} );
 	} );
 
@@ -71,35 +65,6 @@ describe( 'Env', () => {
 			expect( isMac( '' ) ).to.be.false;
 			expect( isMac( 'mac' ) ).to.be.false;
 			expect( isMac( 'foo' ) ).to.be.false;
-		} );
-	} );
-
-	describe( 'isEdge()', () => {
-		it( 'returns true for Edge UA strings', () => {
-			expect( isEdge( 'edge/12' ) ).to.be.true;
-			expect( isEdge( 'foo edge/12 bar' ) ).to.be.true;
-
-			expect( isEdge( toLowerCase(
-				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
-				'Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393'
-			) ) ).to.be.true;
-		} );
-
-		it( 'returns false for non–Edge UA strings', () => {
-			expect( isEdge( '' ) ).to.be.false;
-			expect( isEdge( 'mac' ) ).to.be.false;
-			expect( isEdge( 'foo' ) ).to.be.false;
-			expect( isEdge( 'ledge' ) ).to.be.false;
-			expect( isEdge( 'foo edge bar' ) ).to.be.false;
-
-			// Chrome
-			expect( isEdge( toLowerCase(
-				'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36'
-			) ) ).to.be.false;
-			// IE11
-			expect( isEdge( toLowerCase(
-				'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko'
-			) ) ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
Remove some special cases for Edge, as since it's Chromium-based now, it behaves closer to others.

BREAKING CHANGE: `env.isEdge` is no longer available in utils API, see #6202.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove `env.isEdge`. Closes ckeditor/ckeditor5#6202.

Remove some special cases for Edge, as since it's Chromium-based now, it behaves closer to others.

---

### Additional information

I removed all occurrences of `env.isEdge` and tests for specific behavior in case of its presence. 
Run `npm run test` for Firefox, Chrome. I didn't find any manual tests related to it, so I just check a few random ones.

I was not sure, whether I should touch 
1. https://github.com/ckeditor/ckeditor5-engine/blob/master/src/view/domconverter.js#L172 
  Was the initial, non-Edge/pre-Edge16 intent to use 
`domElement.childNodes.forEach`? (https://caniuse.com/#search=forEach). I leave it as it is, as it's still uniform cross-browser solution.

2. https://github.com/ckeditor/ckeditor5-engine/blob/master/tests/view/renderer.js#L2059
 I guess Chromium-based Edge is no longer an exception here, but I assume it may be still neded for Safari.
3. https://github.com/ckeditor/ckeditor5-image/blob/master/src/imageupload/utils.js#L96 
 According to https://developer.mozilla.org/en-US/docs/Web/API/File#Browser_compatibility since (Chromium-based) Edge 79 constructor is supported. However, I'm not sure whether it is in the scope of this issue.
4. https://github.com/ckeditor/ckeditor5-link/blob/master/src/linkui.js#L188
 I haven't dive deaper, but assume it's needed for FF and not in scope of this issue.
5. https://github.com/ckeditor/ckeditor5-paste-from-office/blob/master/src/filters/space.js#L43 ...
6. https://github.com/ckeditor/ckeditor5-table/blob/master/tests/converters/upcasttable.js#L207 ...
7. https://github.com/ckeditor/ckeditor5-theme-lark/blob/master/theme/ckeditor5-ui/components/button/switchbutton.css#L93 ...
8. https://github.com/ckeditor/ckeditor5-ui/blob/master/src/inputtext/inputtextview.js#L119 ...
9. https://github.com/ckeditor/ckeditor5-ui/blob/master/tests/icon/iconview.js#L134
 Seems 5-9 could be simplified, but I assume that it is not in the scope of this issue.

------------------

And naturally we could consider updating https://github.com/ckeditor/ckeditor5/blob/master/docs/builds/guides/support/browser-compatibility.md#desktop-environment

Branches on other repose linked to this change:
 - https://github.com/ckeditor/ckeditor5-image/compare/i/6202-remove-env.isEdge
 - https://github.com/ckeditor/ckeditor5-engine/compare/i/6202-remove-env.isEdge
 - https://github.com/ckeditor/ckeditor5-horizontal-line/compare/i/6202-remove-env.isEdge
 - https://github.com/ckeditor/ckeditor5-media-embed/compare/i/6202-remove-env.isEdge
 - https://github.com/ckeditor/ckeditor5-mention/compare/i/6202-remove-env.isEdge
 - https://github.com/ckeditor/ckeditor5-page-break/compare/i/6202-remove-env.isEdge
 - https://github.com/ckeditor/ckeditor5-paste-from-office/compare/i/6202-remove-env.isEdge
 - https://github.com/ckeditor/ckeditor5-table/compare/i/6202-remove-env.isEdge
 - https://github.com/ckeditor/ckeditor5-widget/compare/i/6202-remove-env.isEdge

 - https://github.com/ckeditor/ckeditor5-link/compare/i/6202-remove-env.isEdge
 - https://github.com/ckeditor/ckeditor5-theme-lark/compare/i/6202-remove-env.isEdge
 - https://github.com/ckeditor/ckeditor5-ui/compare/i/6202-remove-env.isEdge
 - https://github.com/ckeditor/ckeditor5/compare/i/6202-remove-env.isEdge

