### PR TITLE
Provide support for translating plural forms

### DIFF
--- a/src/locale.js
+++ b/src/locale.js
@@ -79,7 +79,7 @@ export default class Locale {
 		 * Translates the given message to the {@link #uiLanguage}. This method is also available in
 		 * {@link module:core/editor/editor~Editor#t} and {@link module:ui/view~View#t}.
 		 *
-		 * This method's context is statically bound to the `Locale` instance and should be called as a function:
+		 * This method's context is statically bound to the `Locale` instance and **always should be called as a function**:
 		 *
 		 *		const t = locale.t;
 		 *		t( 'Label' );
@@ -92,7 +92,8 @@ export default class Locale {
 		 *		t( 'Created file "%0" in %1ms.', [ fileName, timeTaken ] );
 		 *
 		 * A Message can provide a plural form using the `plural` property and a value - that should be always the first element
-		 * of the `values` array based on which the plural form of the target language should be picked.
+		 * of the `values` array based on which the plural form of the target language should be picked. That property value will
+		 * be used as a default plural translation when the translation for the target language will be missing.
 		 *
 		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, [ spaces ] );
 		 *		t( { string: '%1 a space', plural: '%1 %0 spaces' }, [ spaces, 'Add' ] );
@@ -107,6 +108,7 @@ export default class Locale {
 		 * @method #t
 		 * @param {String|module:utils/translation-service~Message} message A message that will be localized.
 		 * @param {Array.<String>} [values] Values that should be used to interpolate the string.
+		 * @returns {String}
 		 */
 		this.t = ( message, values ) => this._t( message, values );
 	}
@@ -138,8 +140,9 @@ export default class Locale {
 	/**
 	 * Base for the {@link #t} method.
 	 *
-	 * @param {module:utils/translation-service~Message|String} message
+	 * @param {String|module:utils/translation-service~Message} message
 	 * @param {Array.<String>} [values]
+	 * @returns {String}
 	 * @private
 	 */
 	_t( message, values = [] ) {

--- a/src/locale.js
+++ b/src/locale.js
@@ -106,8 +106,9 @@ export default class Locale {
 		 *		t( { string: 'image', context: 'Add/Remove image' } );
 		 *
 		 * @method #t
-		 * @param {String|module:utils/translation-service~Message} message A message that will be localized.
-		 * @param {Array.<String>} [values] Values that should be used to interpolate the string.
+		 * @param {String|module:utils/translation-service~Message} message A message that will be localized (translated).
+		 * @param {Array.<String>} [values] An array of values that will fill message placeholders.
+		 * For messages supporting plural forms the first value will determine the plural form.
 		 * @returns {String}
 		 */
 		this.t = ( message, values ) => this._t( message, values );
@@ -138,12 +139,12 @@ export default class Locale {
 	}
 
 	/**
-	 * Base for the {@link #t} method.
+	 * An unbound version of the {@link #t} method.
 	 *
+	 * @private
 	 * @param {String|module:utils/translation-service~Message} message
 	 * @param {Array.<String>} [values]
 	 * @returns {String}
-	 * @private
 	 */
 	_t( message, values = [] ) {
 		if ( typeof message === 'string' ) {

--- a/src/locale.js
+++ b/src/locale.js
@@ -105,12 +105,11 @@ export default class Locale {
 		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, 5 ); // 'Dodaj 5 spacji' for the Polish language.
 		 *		t( { string: '%1 a space', plural: '%1 %0 spaces' }, [ 2, 'Add' ] ); // 'Dodaj 2 spacje' for the Polish language.
 		 *
-		 * The message can provide a context using the `context` property when the message ids created from message strings
-		 * are not unique. When the `context` property is set the message id will be constructed in
-		 * the following way: `${ message.string }_${ message.context }`. This context will be also used
-		 * by translators later as an additional context for the translated message.
+		 *  * The message should provide an id using the `id` property when the message strings are not unique and their
+		 * translations should be different.
 		 *
-		 *		t( { string: 'image', context: 'Add/Remove image' } );
+		 *		translate( 'en', { string: 'image', id: 'ADD_IMAGE' } );
+		 *		translate( 'en', { string: 'image', id: 'AN_IMAGE' } );
 		 *
 		 * @method #t
 		 * @param {String|module:utils/translation-service~Message} message A message that will be localized (translated).

--- a/src/locale.js
+++ b/src/locale.js
@@ -84,24 +84,24 @@ export default class Locale {
 		 *		const t = locale.t;
 		 *		t( 'Label' );
 		 *
-		 * The message can be either a string or an object implementing the {@link module:translation-service~Message} interface.
+		 * The message can be either a string or an object implementing the {@link module:utils/translation-service~Message} interface.
 		 *
-		 * A Message may contain placeholders (`%<index>`) for values that are passed as the second argument.
+		 * The message may contain placeholders (`%<index>`) for values that are passed as the second argument.
 		 * `<index>` is the index in the `values` array.
 		 *
 		 *		t( 'Created file "%0" in %1ms.', [ fileName, timeTaken ] );
 		 *
-		 * A Message can provide a plural form using the `plural` property and a value - that should be always the first element
-		 * of the `values` array based on which the plural form of the target language should be picked. That property value will
-		 * be used as a default plural translation when the translation for the target language will be missing.
+		 * The message supports plural forms. To specify a plural form, use the `plural` property. Single or plural form
+		 * will be chosen depending on the first value from the passed `values`. The value of this property is
+		 * used as a default plural translation when the translation for the target language is missing.
 		 *
 		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, [ spaces ] );
 		 *		t( { string: '%1 a space', plural: '%1 %0 spaces' }, [ spaces, 'Add' ] );
 		 *
-		 * A Message can provide a context using the `context` property when the message string may be not enough unique
-		 * across all messages. When the `context` property is set the message id will be constructed in
+		 * The message can provide a context using the `context` property when the message ids created from message strings are not unique.
+		 * When the `context` property is set the message id will be constructed in
 		 * the following way: `${ message.string }_${ message.context }`. This context will be also used
-		 * by translators later as a context for the message that should be translated.
+		 * by translators later as an additional context for the translated message.
 		 *
 		 *		t( { string: 'image', context: 'Add/Remove image' } );
 		 *

--- a/src/locale.js
+++ b/src/locale.js
@@ -77,7 +77,7 @@ export default class Locale {
 
 		/**
 		 * Translates the given message to the {@link #uiLanguage}. This method is also available in
-		 * {@link module:core/editor/editor~Editor#t} and {@link module:ui/view~View#t}.
+		 * {@link module:core/editor/editor~Editor#t Editor} and {@link module:ui/view~View#t View}.
 		 *
 		 * This method's context is statically bound to the `Locale` instance and **always should be called as a function**:
 		 *
@@ -86,16 +86,16 @@ export default class Locale {
 		 *
 		 * The message can be either a string or an object implementing the {@link module:utils/translation-service~Message} interface.
 		 *
-		 * The message may contain placeholders (`%<index>`) for value(s) that are passed as the second argument.
+		 * The message may contain placeholders (`%<index>`) for value(s) that are passed as a `values` parameter.
 		 * For an array of values the `%<index>` will be changed to an element of that array at the given index.
 		 * For a single value passed as the second argument, only the `%0` placeholders will be changed to the provided value.
 		 *
 		 *		t( 'Created file "%0" in %1ms.', [ fileName, timeTaken ] );
 		 * 		t( 'Created file "%0", fileName );
 		 *
-		 * The message supports plural forms. To specify a plural form, use the `plural` property. Single or plural form
+         * The message supports plural forms. To specify the plural form, use the `plural` property. Singular or plural form
 		 * will be chosen depending on the first value from the passed `values`. The value of this property is used
-		 * as a default plural translation when the translation for the target language is missing. Therefor, it should be a number.
+		 * as a default plural translation when the translation for the target language is missing. Therefore, it should be a number.
 		 *
 		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, 1 ); // 'Add a space' for the English language.
 		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, 5 ); // 'Add 5 spaces' for the English language.

--- a/src/locale.js
+++ b/src/locale.js
@@ -91,10 +91,10 @@ export default class Locale {
 		 *		t( 'Label' );
 		 *
 		 * @method #t
-		 * @param {String} str The string to translate.
+		 * @param {String} message The string to translate.
 		 * @param {String[]} [values] Values that should be used to interpolate the string.
 		 */
-		this.t = ( ...args ) => this._t( ...args );
+		this.t = ( message, values ) => this._t( message, values );
 	}
 
 	/**
@@ -124,10 +124,19 @@ export default class Locale {
 	/**
 	 * Base for the {@link #t} method.
 	 *
+	 * @param {Object|String} message
+	 * @param {String[]} [values]
 	 * @private
 	 */
-	_t( str, values ) {
-		let translatedString = translate( this.uiLanguage, str );
+	_t( message, values = [] ) {
+		if ( typeof message === 'string' ) {
+			message = { string: message };
+		}
+
+		const hasPluralForm = !!message.plural;
+		const amount = hasPluralForm ? values[ 0 ] : 1;
+
+		let translatedString = translate( this.uiLanguage, message, amount );
 
 		if ( values ) {
 			translatedString = translatedString.replace( /%(\d+)/g, ( match, index ) => {

--- a/src/locale.js
+++ b/src/locale.js
@@ -153,15 +153,12 @@ export default class Locale {
 		const hasPluralForm = !!message.plural;
 		const amount = hasPluralForm ? values[ 0 ] : 1;
 
-		let translatedString = _translate( this.uiLanguage, message, amount );
+		const translatedString = _translate( this.uiLanguage, message, amount );
 
-		if ( values ) {
-			translatedString = translatedString.replace( /%(\d+)/g, ( match, index ) => {
+		return translatedString
+			.replace( /%(\d+)/g, ( match, index ) => {
 				return ( index < values.length ) ? values[ index ] : match;
 			} );
-		}
-
-		return translatedString;
 	}
 }
 

--- a/src/locale.js
+++ b/src/locale.js
@@ -94,7 +94,7 @@ export default class Locale {
 		 * 		t( 'Created file "%0", fileName );
 		 *
          * The message supports plural forms. To specify the plural form, use the `plural` property. Singular or plural form
-		 * will be chosen depending on the first value from the passed `values`. The value of this property is used
+		 * will be chosen depending on the first value from the passed `values`. The value of the `plural` property is used
 		 * as a default plural translation when the translation for the target language is missing. Therefore, it should be a number.
 		 *
 		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, 1 ); // 'Add a space' for the English language.

--- a/src/locale.js
+++ b/src/locale.js
@@ -163,9 +163,9 @@ export default class Locale {
 		}
 
 		const hasPluralForm = !!message.plural;
-		const amount = hasPluralForm ? values[ 0 ] : 1;
+		const quantity = hasPluralForm ? values[ 0 ] : 1;
 
-		const translatedString = _translate( this.uiLanguage, message, amount );
+		const translatedString = _translate( this.uiLanguage, message, quantity );
 
 		return interpolateString( translatedString, values );
 	}

--- a/src/locale.js
+++ b/src/locale.js
@@ -77,21 +77,32 @@ export default class Locale {
 
 		/**
 		 * Translates the given message to the {@link #uiLanguage}. This method is also available in
-		 * {@link module:core/editor/editor~Editor#t} and {@link module:ui/view~View#t}, however this function needs to be called
-		 * as a function to make the translation mechanism work. [TODO]
+		 * {@link module:core/editor/editor~Editor#t} and {@link module:ui/view~View#t}.
+		 *
+		 * This method's context is statically bound to the `Locale` instance and should be called as a function:
+		 *
+		 *		const t = locale.t;
+		 *		t( 'Label' );
 		 *
 		 * The message can be either a string or an object implementing the {@link module:translation-service~Message} interface.
 		 *
-		 * Messages may contain placeholders (`%<index>`) for values that are passed as the second argument.
+		 * A Message may contain placeholders (`%<index>`) for values that are passed as the second argument.
 		 * `<index>` is the index in the `values` array.
 		 *
 		 *		t( 'Created file "%0" in %1ms.', [ fileName, timeTaken ] );
 		 *
-		 * This method's context is statically bound to the `Locale` instance,
-		 * so it can be called as a function:
+		 * A Message can provide a plural form using the `plural` property and a value - that should be always the first element
+		 * of the `values` array based on which the plural form of the target language should be picked.
 		 *
-		 *		const t = this.t;
-		 *		t( 'Label' );
+		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, [ spaces ] );
+		 *		t( { string: '%1 a space', plural: '%1 %0 spaces' }, [ spaces, 'Add' ] );
+		 *
+		 * A Message can provide a context using the `context` property when the message string may be not enough unique
+		 * across all messages. When the `context` property is set the message id will be constructed in
+		 * the following way: `${ message.string }_${ message.context }`. This context will be also used
+		 * by translators later as a context for the message that should be translated.
+		 *
+		 *		t( { string: 'image', context: 'Add/Remove image' } );
 		 *
 		 * @method #t
 		 * @param {String|module:utils/translation-service~Message} message A message that will be localized.

--- a/src/locale.js
+++ b/src/locale.js
@@ -9,7 +9,7 @@
 
 /* globals console */
 
-import { translate } from './translation-service';
+import { _translate } from './translation-service';
 
 const RTL_LANGUAGE_CODES = [ 'ar', 'fa', 'he', 'ku', 'ug' ];
 
@@ -153,7 +153,7 @@ export default class Locale {
 		const hasPluralForm = !!message.plural;
 		const amount = hasPluralForm ? values[ 0 ] : 1;
 
-		let translatedString = translate( this.uiLanguage, message, amount );
+		let translatedString = _translate( this.uiLanguage, message, amount );
 
 		if ( values ) {
 			translatedString = translatedString.replace( /%(\d+)/g, ( match, index ) => {

--- a/src/locale.js
+++ b/src/locale.js
@@ -92,14 +92,19 @@ export default class Locale {
 		 *		t( 'Created file "%0" in %1ms.', [ fileName, timeTaken ] );
 		 *
 		 * The message supports plural forms. To specify a plural form, use the `plural` property. Single or plural form
-		 * will be chosen depending on the first value from the passed `values`. The value of this property is
-		 * used as a default plural translation when the translation for the target language is missing.
+		 * will be chosen depending on the first value from the passed `values`. The value of this property is used
+		 * as a default plural translation when the translation for the target language is missing.
 		 *
-		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, [ spaces ] );
-		 *		t( { string: '%1 a space', plural: '%1 %0 spaces' }, [ spaces, 'Add' ] );
+		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, [ 1 ] ); // 'Add a space' for the English language.
+		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, [ 5 ] ); // 'Add 5 spaces' for the English language.
+		 *		t( { string: '%1 a space', plural: '%1 %0 spaces' }, [ 2, 'Add' ] ); // 'Add 2 spaces' for the English language.
 		 *
-		 * The message can provide a context using the `context` property when the message ids created from message strings are not unique.
-		 * When the `context` property is set the message id will be constructed in
+		 * 		t( { string: 'Add a space', plural: 'Add %0 spaces' }, [ 1 ] ); // 'Dodaj spację' for the Polish language.
+		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, [ 5 ] ); // 'Dodaj 5 spacji' for the Polish language.
+		 *		t( { string: '%1 a space', plural: '%1 %0 spaces' }, [ 2, 'Add' ] ); // 'Dodaj 2 spacje' for the Polish language.
+		 *
+		 * The message can provide a context using the `context` property when the message ids created from message strings
+		 * are not unique. When the `context` property is set the message id will be constructed in
 		 * the following way: `${ message.string }_${ message.context }`. This context will be also used
 		 * by translators later as an additional context for the translated message.
 		 *

--- a/src/locale.js
+++ b/src/locale.js
@@ -87,12 +87,10 @@ export default class Locale {
 		 * The message can be either a string or an object implementing the {@link module:utils/translation-service~Message} interface.
 		 *
 		 * The message may contain placeholders (`%<index>`) for value(s) that are passed as the second argument.
-		 * For an array of values the `<index>` will be the index in that array.
+		 * For an array of values the `%<index>` will be changed to an element of that array at the given index.
+		 * For a single value passed as the second argument, only the `%0` placeholders will be changed to the provided value.
 		 *
 		 *		t( 'Created file "%0" in %1ms.', [ fileName, timeTaken ] );
-		 *
-		 * For only one argument that should be interpolated there's a shorthand:
-		 *
 		 * 		t( 'Created file "%0", fileName );
 		 *
 		 * The message supports plural forms. To specify a plural form, use the `plural` property. Single or plural form

--- a/src/locale.js
+++ b/src/locale.js
@@ -76,23 +76,26 @@ export default class Locale {
 		this.contentLanguageDirection = getLanguageDirection( this.contentLanguage );
 
 		/**
-		 * Translates the given string to the {@link #uiLanguage}. This method is also available in
-		 * {@link module:core/editor/editor~Editor#t} and {@link module:ui/view~View#t}.
+		 * Translates the given message to the {@link #uiLanguage}. This method is also available in
+		 * {@link module:core/editor/editor~Editor#t} and {@link module:ui/view~View#t}, however this function needs to be called
+		 * as a function to make the translation mechanism work. [TODO]
 		 *
-		 * The strings may contain placeholders (`%<index>`) for values which are passed as the second argument.
+		 * The message can be either a string or an object implementing the {@link module:translation-service~Message} interface.
+		 *
+		 * Messages may contain placeholders (`%<index>`) for values that are passed as the second argument.
 		 * `<index>` is the index in the `values` array.
 		 *
-		 *		editor.t( 'Created file "%0" in %1ms.', [ fileName, timeTaken ] );
+		 *		t( 'Created file "%0" in %1ms.', [ fileName, timeTaken ] );
 		 *
-		 * This method's context is statically bound to Locale instance,
+		 * This method's context is statically bound to the `Locale` instance,
 		 * so it can be called as a function:
 		 *
 		 *		const t = this.t;
 		 *		t( 'Label' );
 		 *
 		 * @method #t
-		 * @param {String} message The string to translate.
-		 * @param {String[]} [values] Values that should be used to interpolate the string.
+		 * @param {String|module:utils/translation-service~Message} message A message that will be localized.
+		 * @param {Array.<String>} [values] Values that should be used to interpolate the string.
 		 */
 		this.t = ( message, values ) => this._t( message, values );
 	}
@@ -124,8 +127,8 @@ export default class Locale {
 	/**
 	 * Base for the {@link #t} method.
 	 *
-	 * @param {Object|String} message
-	 * @param {String[]} [values]
+	 * @param {module:utils/translation-service~Message|String} message
+	 * @param {Array.<String>} [values]
 	 * @private
 	 */
 	_t( message, values = [] ) {

--- a/src/locale.js
+++ b/src/locale.js
@@ -93,9 +93,9 @@ export default class Locale {
 		 *		t( 'Created file "%0" in %1ms.', [ fileName, timeTaken ] );
 		 * 		t( 'Created file "%0", fileName );
 		 *
-         * The message supports plural forms. To specify the plural form, use the `plural` property. Singular or plural form
+		 * The message supports plural forms. To specify the plural form, use the `plural` property. Singular or plural form
 		 * will be chosen depending on the first value from the passed `values`. The value of the `plural` property is used
-		 * as a default plural translation when the translation for the target language is missing. Therefore, it should be a number.
+		 * as a default plural translation when the translation for the target language is missing.
 		 *
 		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, 1 ); // 'Add a space' for the English language.
 		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, 5 ); // 'Add 5 spaces' for the English language.

--- a/src/locale.js
+++ b/src/locale.js
@@ -86,21 +86,25 @@ export default class Locale {
 		 *
 		 * The message can be either a string or an object implementing the {@link module:utils/translation-service~Message} interface.
 		 *
-		 * The message may contain placeholders (`%<index>`) for values that are passed as the second argument.
-		 * `<index>` is the index in the `values` array.
+		 * The message may contain placeholders (`%<index>`) for value(s) that are passed as the second argument.
+		 * For an array of values the `<index>` will be the index in that array.
 		 *
 		 *		t( 'Created file "%0" in %1ms.', [ fileName, timeTaken ] );
 		 *
+		 * For only one argument that should be interpolated there's a shorthand:
+		 *
+		 * 		t( 'Created file "%0", fileName );
+		 *
 		 * The message supports plural forms. To specify a plural form, use the `plural` property. Single or plural form
 		 * will be chosen depending on the first value from the passed `values`. The value of this property is used
-		 * as a default plural translation when the translation for the target language is missing.
+		 * as a default plural translation when the translation for the target language is missing. Therefor, it should be a number.
 		 *
-		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, [ 1 ] ); // 'Add a space' for the English language.
-		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, [ 5 ] ); // 'Add 5 spaces' for the English language.
+		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, 1 ); // 'Add a space' for the English language.
+		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, 5 ); // 'Add 5 spaces' for the English language.
 		 *		t( { string: '%1 a space', plural: '%1 %0 spaces' }, [ 2, 'Add' ] ); // 'Add 2 spaces' for the English language.
 		 *
-		 * 		t( { string: 'Add a space', plural: 'Add %0 spaces' }, [ 1 ] ); // 'Dodaj spację' for the Polish language.
-		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, [ 5 ] ); // 'Dodaj 5 spacji' for the Polish language.
+		 * 		t( { string: 'Add a space', plural: 'Add %0 spaces' }, 1 ); // 'Dodaj spację' for the Polish language.
+		 *		t( { string: 'Add a space', plural: 'Add %0 spaces' }, 5 ); // 'Dodaj 5 spacji' for the Polish language.
 		 *		t( { string: '%1 a space', plural: '%1 %0 spaces' }, [ 2, 'Add' ] ); // 'Dodaj 2 spacje' for the Polish language.
 		 *
 		 * The message can provide a context using the `context` property when the message ids created from message strings
@@ -112,7 +116,7 @@ export default class Locale {
 		 *
 		 * @method #t
 		 * @param {String|module:utils/translation-service~Message} message A message that will be localized (translated).
-		 * @param {Array.<String>} [values] An array of values that will fill message placeholders.
+		 * @param {String|Number|Array.<String|Number>} [values] A value or an array of values that will fill message placeholders.
 		 * For messages supporting plural forms the first value will determine the plural form.
 		 * @returns {String}
 		 */
@@ -148,10 +152,14 @@ export default class Locale {
 	 *
 	 * @private
 	 * @param {String|module:utils/translation-service~Message} message
-	 * @param {Array.<String>} [values]
+	 * @param {Number|String|Array.<Number|String>} [values]
 	 * @returns {String}
 	 */
 	_t( message, values = [] ) {
+		if ( !Array.isArray( values ) ) {
+			values = [ values ];
+		}
+
 		if ( typeof message === 'string' ) {
 			message = { string: message };
 		}
@@ -161,11 +169,15 @@ export default class Locale {
 
 		const translatedString = _translate( this.uiLanguage, message, amount );
 
-		return translatedString
-			.replace( /%(\d+)/g, ( match, index ) => {
-				return ( index < values.length ) ? values[ index ] : match;
-			} );
+		return interpolateString( translatedString, values );
 	}
+}
+
+// Fills the `%0, %1, ...` string placeholders with values.
+function interpolateString( string, values ) {
+	return string.replace( /%(\d+)/g, ( match, index ) => {
+		return ( index < values.length ) ? values[ index ] : match;
+	} );
 }
 
 // Helps determine whether a language is LTR or RTL.

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -31,7 +31,7 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  *			'image_Insert image': 'obraz', // Note that the `Insert image` comes from the message context.
  *		} );
  *
- * If the message is supposed to support various plural forms, make sure to provide an array with the single form and all plural forms:
+ * If the message is supposed to support various plural forms, make sure to provide an array with the singular form and all plural forms:
  *
  *		add( 'pl', {
  *	 		'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ]

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -26,7 +26,7 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  * If the message supports plural forms, make sure to provide an array with all plural forms:
  *
  *		add( 'pl', {
- *	 		'Add editor': [ 'Dodaj edytor', 'Dodaj %0 edytory', 'Dodaj %0 edytorów' ]
+ *	 		'Add spaces': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ]
  * 		} );
  *
  * If you cannot import this function from this module (e.g. because you use a CKEditor 5 build), then you can

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -41,6 +41,9 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  * language file was loaded for that language. All language files coming from CKEditor 5 sources will have this option set, so
  * these plural form rules will be reused by other translations added to the registered languages.
  *
+ * 		add( 'en', {
+ *	 		// ... Translations.
+ * 		}, n => n !== 1 );
  * 		add( 'pl', {
  *	 		// ... Translations.
  * 		}, n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 );

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -49,7 +49,11 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  * @param {Function} getPluralForm A function that returns the plural form index.
  */
 export function add( language, translations, getPluralForm ) {
-	const languageTranslations = window.CKEDITOR_TRANSLATIONS[ language ] || ( window.CKEDITOR_TRANSLATIONS[ language ] = {} );
+	if ( !window.CKEDITOR_TRANSLATIONS[ language ] ) {
+		window.CKEDITOR_TRANSLATIONS[ language ] = {};
+	}
+
+	const languageTranslations = window.CKEDITOR_TRANSLATIONS[ language ];
 
 	languageTranslations.dictionary = languageTranslations.dictionary || {};
 	languageTranslations.getPluralForm = getPluralForm || languageTranslations.getPluralForm;
@@ -73,8 +77,8 @@ export function add( language, translations, getPluralForm ) {
  * The third optional argument is the number of elements, based on which the single form or one of plural forms
  * should be picked when the message supports plural forms.
  *
- * 		translate( 'en', { string: 'Add a space', plural: 'Add %0 spaces }, 1 ); // 'Add %0 space'
- * 		translate( 'en', { string: 'Add a space', plural: 'Add %0 spaces }, 3 ); // 'Add %0 spaces'
+ * 		translate( 'en', { string: 'Add a space', plural: 'Add %0 spaces' }, 1 ); // 'Add a space'
+ * 		translate( 'en', { string: 'Add a space', plural: 'Add %0 spaces' }, 3 ); // 'Add %0 spaces'
  *
  * @param {String} language Target language.
  * @param {module:utils/translation-service~Message|string} message A message that will be translated.
@@ -97,13 +101,14 @@ export function translate( language, message, amount = 1 ) {
 		language = Object.keys( window.CKEDITOR_TRANSLATIONS )[ 0 ];
 	}
 
+	// Use message context to enhance the message id when passed.
 	const messageId = message.context ?
 		message.string + '_' + message.context :
 		message.string;
 
 	if ( numberOfLanguages === 0 || !hasTranslation( language, messageId ) ) {
-		// return english forms:
 		if ( amount !== 1 ) {
+			// Return the default plural form that was passed in the `message.plural` parameter.
 			return message.plural;
 		}
 
@@ -145,7 +150,7 @@ function getNumberOfLanguages() {
 }
 
 /**
- * The internalization message interface. A translation for the given language can be found.
+ * The internationalization message interface. A translation for the given language can be found.
  *
  * TODO
  *

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -20,7 +20,7 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  *
  *		add( 'pl', {
  *			'OK': 'OK',
- *			'Cancel [context: reject]': 'Anuluj'
+ *			'Cancel': 'Anuluj'
  *		} );
  *
  * If the message supports plural forms, make sure to provide an array with all plural forms:
@@ -68,20 +68,27 @@ export function add( language, translations, getPluralForm ) {
  * In a single-language mode (when values passed to `t()` were replaced with target language strings) the dictionary
  * is left empty, so this function will return the original strings always.
  *
- *		translate( 'pl', 'Cancel' );
+ *		translate( 'pl', { string: 'Cancel' } );
  *
  * The third optional argument is the number of elements, based on which the single form or one of plural forms
  * should be picked when the message supports plural forms.
  *
- * 		translate( 'en', 'Add a space', 1 ); // 'Add %0 space'
- * 		translate( 'en', 'Add a space', 3 ); // 'Add %0 spaces'
+ * 		translate( 'en', { string: 'Add a space', plural: 'Add %0 spaces }, 1 ); // 'Add %0 space'
+ * 		translate( 'en', { string: 'Add a space', plural: 'Add %0 spaces }, 3 ); // 'Add %0 spaces'
  *
  * @param {String} language Target language.
- * @param {Object} message A message that will be translated.
+ * @param {module:utils/translation-service~Message|string} message A message that will be translated.
  * @param {Number} [amount] A number of elements for which a plural form should be picked from the target language dictionary.
  * @returns {String} Translated sentence.
  */
 export function translate( language, message, amount = 1 ) {
+	if ( typeof message === 'string' ) {
+		// TODO
+		console.warn( 'DEPRECATED' );
+
+		message = { string: message };
+	}
+
 	const numberOfLanguages = getNumberOfLanguages();
 
 	if ( numberOfLanguages === 1 ) {
@@ -90,11 +97,9 @@ export function translate( language, message, amount = 1 ) {
 		language = Object.keys( window.CKEDITOR_TRANSLATIONS )[ 0 ];
 	}
 
-	// TODO
-	// const messageId = message.context ?
-	// 	message.string + '_' + message.context :
-	// 	message.string;
-	const messageId = message.string;
+	const messageId = message.context ?
+		message.string + '_' + message.context :
+		message.string;
 
 	if ( numberOfLanguages === 0 || !hasTranslation( language, messageId ) ) {
 		// return english forms:
@@ -138,3 +143,16 @@ function hasTranslation( language, messageId ) {
 function getNumberOfLanguages() {
 	return Object.keys( window.CKEDITOR_TRANSLATIONS ).length;
 }
+
+/**
+ * The internalization message interface. A translation for the given language can be found.
+ *
+ * TODO
+ *
+ * @typedef {Object} Message
+ *
+ * @property {String} string The message string. It becomes the message id when no context is provided.
+ * @property {String} [context] The message context. If passed then the message id is constructed form both,
+ * the message string and the message string in the following format: `<messageString>_<messageContext>`.
+ * @property {String} [plural] The plural form of the message.
+ */

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -70,11 +70,11 @@ export function add( language, translations, getFormIndex ) {
  *
  *		translate( 'pl', 'Cancel' );
  *
- * The third optional argument is the number of elements, based on which the plural form should be picked when the message
- * supports plural forms.
+ * The third optional argument is the number of elements, based on which the single form or one of plural forms
+ * should be picked when the message supports plural forms.
  *
- * 		translate( 'en', 'Add a space', 1 ); // 'Add a space'
- * 		translate( 'en', 'Add a space', 3 ); // 'Add 3 spaces'
+ * 		translate( 'en', 'Add a space', 1 ); // 'Add %0 space'
+ * 		translate( 'en', 'Add a space', 3 ); // 'Add %0 spaces'
  *
  * @param {String} language Target language.
  * @param {Object} message A message that will be translated.

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -155,7 +155,7 @@ export function _translate( language, message, quantity = 1 ) {
 		return dictionary[ messageId ];
 	}
 
-	const pluralFormIndex = getPluralForm( quantity );
+	const pluralFormIndex = Number( getPluralForm( quantity ) );
 
 	// Note: The `translate` function is not responsible for replacing `%0, %1, ...` with values.
 	return dictionary[ messageId ][ pluralFormIndex ];

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals window, console */
+/* globals window */
 
 /**
  * @module utils/translation-service
@@ -80,19 +80,13 @@ export function add( language, translations, getPluralForm ) {
  * 		translate( 'en', { string: 'Add a space', plural: 'Add %0 spaces' }, 1 ); // 'Add a space'
  * 		translate( 'en', { string: 'Add a space', plural: 'Add %0 spaces' }, 3 ); // 'Add %0 spaces'
  *
+ * @protected
  * @param {String} language Target language.
  * @param {module:utils/translation-service~Message|string} message A message that will be translated.
  * @param {Number} [amount] A number of elements for which a plural form should be picked from the target language dictionary.
  * @returns {String} Translated sentence.
  */
-export function translate( language, message, amount = 1 ) {
-	if ( typeof message === 'string' ) {
-		// TODO
-		console.warn( 'deprecated usage' );
-
-		message = { string: message };
-	}
-
+export function _translate( language, message, amount = 1 ) {
 	const numberOfLanguages = getNumberOfLanguages();
 
 	if ( numberOfLanguages === 1 ) {

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -23,6 +23,12 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  *			'Cancel [context: reject]': 'Anuluj'
  *		} );
  *
+ * If the message supports plural forms, make sure to provide an array with all plural forms:
+ *
+ *		add( 'pl', {
+ *	 		'Add editor': [ 'Dodaj edytor', 'Dodaj %0 edytory', 'Dodaj %0 edytorów' ]
+ * 		} );
+ *
  * If you cannot import this function from this module (e.g. because you use a CKEditor 5 build), then you can
  * still add translations by extending the global `window.CKEDITOR_TRANSLATIONS` object by using a function like
  * the one below:
@@ -57,19 +63,25 @@ export function add( language, translations, getFormIndex ) {
  * This happens in a multi-language mode were translation modules are created by the bundler.
  *
  * When no translation is defined in the dictionary or the dictionary doesn't exist this function returns
- * the original string without the `'[context: ]'` (happens in development and single-language modes).
+ * the original string.
  *
  * In a single-language mode (when values passed to `t()` were replaced with target language strings) the dictionary
  * is left empty, so this function will return the original strings always.
  *
- *		translate( 'pl', 'Cancel [context: reject]' );
+ *		translate( 'pl', 'Cancel' );
+ *
+ * The third optional argument is the number of elements, based on which the plural form should be picked when the message
+ * supports plural forms.
+ *
+ * 		translate( 'en', 'Add a space', 1 ); // 'Add a space'
+ * 		translate( 'en', 'Add a space', 3 ); // 'Add 3 spaces'
  *
  * @param {String} language Target language.
  * @param {Object} message A message that will be translated.
- * @param {Number} amount
+ * @param {Number} [amount] A number of elements for which a plural form should be picked from the target language dictionary.
  * @returns {String} Translated sentence.
  */
-export function translate( language, message, amount ) {
+export function translate( language, message, amount = 1 ) {
 	const numberOfLanguages = getNumberOfLanguages();
 
 	if ( numberOfLanguages === 1 ) {
@@ -78,7 +90,11 @@ export function translate( language, message, amount ) {
 		language = Object.keys( window.CKEDITOR_TRANSLATIONS )[ 0 ];
 	}
 
-	const messageId = message.id || message.string;
+	// TODO
+	// const messageId = message.context ?
+	// 	message.string + '_' + message.context :
+	// 	message.string;
+	const messageId = message.string;
 
 	if ( numberOfLanguages === 0 || !hasTranslation( language, messageId ) ) {
 		// return english forms:

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -62,7 +62,9 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  *		}
  *
  * @param {String} language Target language.
- * @param {Object.<String, String|Array.<String>>} translations Translations which will be added to the dictionary.
+ * @param {Object.<String,*>} translations An object with translations which will be added to the dictionary.
+ * For each message id the value should be either a translation or an array of translations if the message
+ * should support plural forms.
  * @param {Function} getPluralForm A function that returns the plural form index (a number).
  */
 export function add( language, translations, getPluralForm ) {
@@ -79,7 +81,7 @@ export function add( language, translations, getPluralForm ) {
 }
 
 /**
- * **Note:** this method is internal, use {@link module:utils/local~Locale#t the `t()` function} instead to translate
+ * **Note:** this method is internal, use {@link module:utils/locale~Locale#t the `t()` function} instead to translate
  * editor UI parts.
  *
  * This function is responsible for translating messages to the specified language. It uses perviously added translations
@@ -104,7 +106,7 @@ export function add( language, translations, getPluralForm ) {
  *
  * @protected
  * @param {String} language Target language.
- * @param {module:utils/translation-service~Message|string} message A message that will be translated.
+ * @param {module:utils/translation-service~Message|String} message A message that will be translated.
  * @param {Number} [amount] A number of elements for which a plural form should be picked from the target language dictionary.
  * @returns {String} Translated sentence.
  */

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -21,14 +21,14 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  * be available for the {@link module:utils/locale~Locale#t `t()`} function.
  *
  * The `translations` is an object which consists of a `messageId: translation` pairs. Note that the message id can be
- * either constructed either from the message string or from the message string and the message context in the following form:
- * `<messageString>_<messageContext>` (this happens rarely and mostly for short messages or messages with placeholders).
- * Since the editor displays only the message string, the message context can be found either in the source code or in the
+ * either constructed either from the message string or from the message id if it was passed
+ * (this happens rarely and mostly for short messages or messages with placeholders).
+ * Since the editor displays only the message string, the message id can be found either in the source code or in the
  * built translations for another language.
  *
  *		add( 'pl', {
  *			'Cancel': 'Anuluj',
- *			'image_Insert image': 'obraz', // Note that the `Insert image` comes from the message context.
+ *			'IMAGE': 'obraz', // Note that the `IMAGE` comes from the message id, while the string can be `image`.
  *		} );
  *
  * If the message is supposed to support various plural forms, make sure to provide an array with the singular form and all plural forms:
@@ -105,12 +105,11 @@ export function add( language, translations, getPluralForm ) {
  * 		translate( 'en', { string: 'Add a space', plural: 'Add %0 spaces' }, 1 ); // 'Add a space'
  * 		translate( 'en', { string: 'Add a space', plural: 'Add %0 spaces' }, 3 ); // 'Add %0 spaces'
  *
- * The message can provide a context using the `context` property when the message ids created from message strings
- * are not unique. When the `context` property is set the message id will be constructed in
- * the following way: `${ message.string }_${ message.context }`. This context will be also used
- * by translators later as an additional context for the translated message.
+ * The message should provide an id using the `id` property when the message strings are not unique and their
+ * translations should be different.
  *
- *		translate( 'en', { string: 'image', context: 'Add/Remove image' } );
+ *		translate( 'en', { string: 'image', id: 'ADD_IMAGE' } );
+ *		translate( 'en', { string: 'image', id: 'AN_IMAGE' } );
  *
  * @protected
  * @param {String} language Target language.
@@ -138,10 +137,7 @@ export function _translate( language, message, quantity = 1 ) {
 		language = Object.keys( window.CKEDITOR_TRANSLATIONS )[ 0 ];
 	}
 
-	// Use message context to enhance the message id when passed.
-	const messageId = message.context ?
-		message.string + '_' + message.context :
-		message.string;
+	const messageId = message.id || message.string;
 
 	if ( numberOfLanguages === 0 || !hasTranslation( language, messageId ) ) {
 		if ( quantity !== 1 ) {
@@ -194,9 +190,9 @@ function getNumberOfLanguages() {
  *
  * @property {String} string The message string to translate. Acts as a default translation if the translation for given language
  * is not defined. When the message is supposed to support plural forms then the string should be the English singular form of the message.
- * @property {String} [context] The message context. If passed then the message id is constructed form both,
- * the message string and the message string in the following format: `<messageString>_<messageContext>`. This property is useful when
- * various messages can share the same message string, when omitting a context would result in a broken translation.
+ * @property {String} [id] The message id. If passed then the message id is taken from this property instead of the `message.string`.
+ * This property is useful when various messages share the same message string. E.g. `editor` string in `in the editor` and `my editor`
+ * sentences.
  * @property {String} [plural] The plural form of the message. This property should be skipped when a message is not supposed
  * to support plural forms. Otherwise it should always be set to a string with the English plural form of the message.
  */

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -132,8 +132,6 @@ export function _translate( language, message, amount = 1 ) {
 	const dictionary = window.CKEDITOR_TRANSLATIONS[ language ].dictionary;
 	const getPluralForm = window.CKEDITOR_TRANSLATIONS[ language ].getPluralForm || ( n => n === 1 ? 0 : 1 );
 
-	// TODO - maybe a warning could be helpful for some mismatches.
-
 	if ( typeof dictionary[ messageId ] === 'string' ) {
 		return dictionary[ messageId ];
 	}
@@ -166,14 +164,16 @@ function getNumberOfLanguages() {
 }
 
 /**
- * The internationalization message interface. A translation for the given language can be found.
- *
- * TODO
+ * The internationalization message interface. A message that implements this interface can be passed to the `t()` function
+ * to be translated to the target ui language.
  *
  * @typedef {Object} Message
  *
- * @property {String} string The message string. It becomes the message id when no context is provided.
+ * @property {String} string The message string. It becomes the message id when no context is provided. When the message is supposed
+ * to support plural forms then the string should be the English singular form of the message.
  * @property {String} [context] The message context. If passed then the message id is constructed form both,
- * the message string and the message string in the following format: `<messageString>_<messageContext>`.
- * @property {String} [plural] The plural form of the message.
+ * the message string and the message string in the following format: `<messageString>_<messageContext>`. This property is useful when
+ * various messages can share the same message string, when omitting a context would result in a broken translation.
+ * @property {String} [plural] The plural form of the message. This property should be skipped when a message is not supposed
+ * to support plural forms. Otherwise it should always be set to a string with the English plural form of the message.
  */

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -46,13 +46,13 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  *
  * @param {String} language Target language.
  * @param {Object.<String, String>} translations Translations which will be added to the dictionary.
- * @param {Function} getFormIndex
+ * @param {Function} getPluralForm A function that returns the plural form index.
  */
-export function add( language, translations, getFormIndex ) {
+export function add( language, translations, getPluralForm ) {
 	const languageTranslations = window.CKEDITOR_TRANSLATIONS[ language ] || ( window.CKEDITOR_TRANSLATIONS[ language ] = {} );
 
 	languageTranslations.dictionary = languageTranslations.dictionary || {};
-	languageTranslations.getFormIndex = getFormIndex || languageTranslations.getFormIndex || ( () => 0 );
+	languageTranslations.getPluralForm = getPluralForm || languageTranslations.getPluralForm || ( () => 0 );
 
 	Object.assign( languageTranslations.dictionary, translations );
 }
@@ -106,7 +106,7 @@ export function translate( language, message, amount = 1 ) {
 	}
 
 	const dictionary = window.CKEDITOR_TRANSLATIONS[ language ].dictionary;
-	const getFormIndex = window.CKEDITOR_TRANSLATIONS[ language ].getFormIndex;
+	const getPluralForm = window.CKEDITOR_TRANSLATIONS[ language ].getPluralForm;
 
 	// TODO - maybe a warning could be helpful for some mismatches.
 
@@ -115,7 +115,7 @@ export function translate( language, message, amount = 1 ) {
 	}
 
 	// Note: The `translate` function is not responsible for replacing `%0, %1, ...` with values.
-	return dictionary[ messageId ][ getFormIndex( amount ) ];
+	return dictionary[ messageId ][ getPluralForm( amount ) ];
 }
 
 /**

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -17,13 +17,13 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
 }
 
 /**
- * Adds translations to existing ones or overrides the existing translations. these translations will later
+ * Adds translations to existing ones or overrides the existing translations. These translations will later
  * be available for the {@link module:utils/locale~Locale#t `t()`} function.
  *
- * The `translations` is an object which consists of a `message id - translation` pairs. Note that message id can be
- * either constructed either from the message string or from the message string and message context in the following form:
+ * The `translations` is an object which consists of a `messageId: translation` pairs. Note that the message id can be
+ * either constructed either from the message string or from the message string and the message context in the following form:
  * `<messageString>_<messageContext>` (this happens rarely and mostly for short messages or messages with placeholders).
- * Since the editor displays only the message string the message context can be found either in the source code or in the
+ * Since the editor displays only the message string, the message context can be found either in the source code or in the
  * built translations for another language.
  *
  *		add( 'pl', {
@@ -42,7 +42,7 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  * these plural form rules will be reused by other translations added to the registered languages.
  *
  * 		add( 'pl', {
- *	 		// Translations.
+ *	 		// ... Translations.
  * 		}, n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 );
  *
  * If you cannot import this function from this module (e.g. because you use a CKEditor 5 build), then you can

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -9,6 +9,8 @@
  * @module utils/translation-service
  */
 
+import CKEditorError from './ckeditorerror';
+
 /* istanbul ignore else */
 if ( !window.CKEDITOR_TRANSLATIONS ) {
 	window.CKEDITOR_TRANSLATIONS = {};
@@ -107,6 +109,17 @@ export function add( language, translations, getPluralForm ) {
  * @returns {String} Translated sentence.
  */
 export function _translate( language, message, amount = 1 ) {
+	if ( typeof amount !== 'number' ) {
+		/**
+		 * The incorrect value has been passed to the `translation` function. This probably was caused
+		 * by the incorrect message interpolation of a plural form. Note that for messages supporting plural forms
+		 * the second argument of the `t()` function should always be a number or an array with number as the first element.
+		 *
+		 * @error translation-service-amount-not-a-number
+		 */
+		throw new CKEditorError( 'translation-service-amount-not-a-number: Expecting `amount` to be a number.', null, { amount } );
+	}
+
 	const numberOfLanguages = getNumberOfLanguages();
 
 	if ( numberOfLanguages === 1 ) {

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -17,26 +17,32 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
 }
 
 /**
- * Adds translations to existing ones or overrides the existing translations.
+ * Adds translations to existing ones or overrides the existing translations. these translations will later
+ * be available for the {@link module:utils/locale~Locale#t `t()`} function.
  *
- * These translations will later be available for the {@link module:utils/locale~Locale#t `t()`} function.
+ * The `translations` is an object which consists of a `message id - translation` pairs. Note that message id can be
+ * either constructed either from the message string or from the message string and message context in the following form:
+ * `<messageString>_<messageContext>` (this happens rarely and mostly for short messages or messages with placeholders).
+ * Since the editor displays only the message string the message context can be found either in the source code or in the
+ * built translations for another language.
  *
  *		add( 'pl', {
  *			'Cancel': 'Anuluj',
- *			'Heading': 'Nagłówek'
- *		}, n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 );
+ *			'image_Insert image': 'obraz', // Note that the `Insert image` comes from the message context.
+ *		} );
  *
- * If a message is supposed to support various plural forms, make sure to provide an array with the single form and all plural forms:
+ * If the message is supposed to support various plural forms, make sure to provide an array with the single form and all plural forms:
  *
  *		add( 'pl', {
  *	 		'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ]
  * 		} );
  *
- * You should also specify the third argument (the `getPluralForm` function) that will be used to determine the plural form if the
- * language is not supported by CKEditor 5 yet.
+ * You should also specify the third argument (the `getPluralForm` function) that will be used to determine the plural form if no
+ * language file was loaded for that language. All language files coming from CKEditor 5 sources will have this option set, so
+ * these plural form rules will be reused by other translations added to the registered languages.
  *
  * 		add( 'pl', {
- *	 		'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ]
+ *	 		// Translations.
  * 		}, n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 );
  *
  * If you cannot import this function from this module (e.g. because you use a CKEditor 5 build), then you can
@@ -99,10 +105,12 @@ export function add( language, translations, getPluralForm ) {
  * 		translate( 'en', { string: 'Add a space', plural: 'Add %0 spaces' }, 1 ); // 'Add a space'
  * 		translate( 'en', { string: 'Add a space', plural: 'Add %0 spaces' }, 3 ); // 'Add %0 spaces'
  *
- * A Message can provide a context using the `context` property when the message string may be not enough unique
- * across all messages. When the `context` property is set the message id will be constructed in
+ * The message can provide a context using the `context` property when the message ids created from message strings
+ * are not unique. When the `context` property is set the message id will be constructed in
  * the following way: `${ message.string }_${ message.context }`. This context will be also used
- * by translators later as a context for the message that should be translated.
+ * by translators later as an additional context for the translated message.
+ *
+ *		translate( 'en', { string: 'image', context: 'Add/Remove image' } );
  *
  * @protected
  * @param {String} language Target language.
@@ -184,8 +192,8 @@ function getNumberOfLanguages() {
  *
  * @typedef {Object} Message
  *
- * @property {String} string The message string. It becomes the message id when no context is provided. When the message is supposed
- * to support plural forms then the string should be the English singular form of the message.
+ * @property {String} string The message string to translate. Acts as a default translation if the translation for given language
+ * is not defined. When the message is supposed to support plural forms then the string should be the English singular form of the message.
  * @property {String} [context] The message context. If passed then the message id is constructed form both,
  * the message string and the message string in the following format: `<messageString>_<messageContext>`. This property is useful when
  * various messages can share the same message string, when omitting a context would result in a broken translation.

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -49,6 +49,20 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  *	 		// ... Translations.
  * 		}, n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 );
  *
+ * All translations extend the global `window.CKEDITOR_TRANSLATIONS` object. An example of this object can be found below:
+ *
+ * 		{
+ * 			pl: {
+ *				dictionary: {
+ *					'Cancel': 'Anuluj',
+ *					'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ]
+ *				},
+ *				// A function that returns the plural form index.
+ *				getPluralForm: n => n !==1
+ *			}
+ *			// other languages.
+ *		}
+ *
  * If you cannot import this function from this module (e.g. because you use a CKEditor 5 build), then you can
  * still add translations by extending the global `window.CKEDITOR_TRANSLATIONS` object by using a function like
  * the one below:

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -21,7 +21,7 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  * be available for the {@link module:utils/locale~Locale#t `t()`} function.
  *
  * The `translations` is an object which consists of a `messageId: translation` pairs. Note that the message id can be
- * either constructed either from the message string or from the message id if it was passed
+ * either constructed from the message string or from the message id if it was passed
  * (this happens rarely and mostly for short messages or messages with placeholders).
  * Since the editor displays only the message string, the message id can be found either in the source code or in the
  * built translations for another language.

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals window */
+/* globals window, console */
 
 /**
  * @module utils/translation-service
@@ -84,7 +84,7 @@ export function add( language, translations, getPluralForm ) {
 export function translate( language, message, amount = 1 ) {
 	if ( typeof message === 'string' ) {
 		// TODO
-		console.warn( 'DEPRECATED' );
+		console.warn( 'deprecated usage' );
 
 		message = { string: message };
 	}
@@ -135,8 +135,8 @@ export function _clear() {
 // Checks whether the dictionary exists and translation in that dictionary exists.
 function hasTranslation( language, messageId ) {
 	return (
-		window.CKEDITOR_TRANSLATIONS[ language ] &&
-		window.CKEDITOR_TRANSLATIONS[ language ].dictionary[ messageId ]
+		!!window.CKEDITOR_TRANSLATIONS[ language ] &&
+		!!window.CKEDITOR_TRANSLATIONS[ language ].dictionary[ messageId ]
 	);
 }
 

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -39,7 +39,8 @@ if ( !window.CKEDITOR_TRANSLATIONS ) {
  *
  * You should also specify the third argument (the `getPluralForm` function) that will be used to determine the plural form if no
  * language file was loaded for that language. All language files coming from CKEditor 5 sources will have this option set, so
- * these plural form rules will be reused by other translations added to the registered languages.
+ * these plural form rules will be reused by other translations added to the registered languages. The `getPluralForm` function
+ * can return either a boolean or a number.
  *
  * 		add( 'en', {
  *	 		// ... Translations.

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -115,19 +115,19 @@ export function add( language, translations, getPluralForm ) {
  * @protected
  * @param {String} language Target language.
  * @param {module:utils/translation-service~Message|String} message A message that will be translated.
- * @param {Number} [amount] A number of elements for which a plural form should be picked from the target language dictionary.
+ * @param {Number} [quantity] A number of elements for which a plural form should be picked from the target language dictionary.
  * @returns {String} Translated sentence.
  */
-export function _translate( language, message, amount = 1 ) {
-	if ( typeof amount !== 'number' ) {
+export function _translate( language, message, quantity = 1 ) {
+	if ( typeof quantity !== 'number' ) {
 		/**
 		 * The incorrect value has been passed to the `translation` function. This probably was caused
 		 * by the incorrect message interpolation of a plural form. Note that for messages supporting plural forms
 		 * the second argument of the `t()` function should always be a number or an array with number as the first element.
 		 *
-		 * @error translation-service-amount-not-a-number
+		 * @error translation-service-quantity-not-a-number
 		 */
-		throw new CKEditorError( 'translation-service-amount-not-a-number: Expecting `amount` to be a number.', null, { amount } );
+		throw new CKEditorError( 'translation-service-quantity-not-a-number: Expecting `quantity` to be a number.', null, { quantity } );
 	}
 
 	const numberOfLanguages = getNumberOfLanguages();
@@ -144,7 +144,7 @@ export function _translate( language, message, amount = 1 ) {
 		message.string;
 
 	if ( numberOfLanguages === 0 || !hasTranslation( language, messageId ) ) {
-		if ( amount !== 1 ) {
+		if ( quantity !== 1 ) {
 			// Return the default plural form that was passed in the `message.plural` parameter.
 			return message.plural;
 		}
@@ -159,7 +159,7 @@ export function _translate( language, message, amount = 1 ) {
 		return dictionary[ messageId ];
 	}
 
-	const pluralFormIndex = getPluralForm( amount );
+	const pluralFormIndex = getPluralForm( quantity );
 
 	// Note: The `translate` function is not responsible for replacing `%0, %1, ...` with values.
 	return dictionary[ messageId ][ pluralFormIndex ];

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -190,7 +190,7 @@ function getNumberOfLanguages() {
  * The internationalization message interface. A message that implements this interface can be passed to the `t()` function
  * to be translated to the target ui language.
  *
- * @typedef {Object} Message
+ * @typedef {Object} module:utils/translation-service~Message
  *
  * @property {String} string The message string to translate. Acts as a default translation if the translation for given language
  * is not defined. When the message is supposed to support plural forms then the string should be the English singular form of the message.

--- a/src/translation-service.js
+++ b/src/translation-service.js
@@ -52,7 +52,7 @@ export function add( language, translations, getPluralForm ) {
 	const languageTranslations = window.CKEDITOR_TRANSLATIONS[ language ] || ( window.CKEDITOR_TRANSLATIONS[ language ] = {} );
 
 	languageTranslations.dictionary = languageTranslations.dictionary || {};
-	languageTranslations.getPluralForm = getPluralForm || languageTranslations.getPluralForm || ( () => 0 );
+	languageTranslations.getPluralForm = getPluralForm || languageTranslations.getPluralForm;
 
 	Object.assign( languageTranslations.dictionary, translations );
 }
@@ -111,7 +111,7 @@ export function translate( language, message, amount = 1 ) {
 	}
 
 	const dictionary = window.CKEDITOR_TRANSLATIONS[ language ].dictionary;
-	const getPluralForm = window.CKEDITOR_TRANSLATIONS[ language ].getPluralForm;
+	const getPluralForm = window.CKEDITOR_TRANSLATIONS[ language ].getPluralForm || ( n => n === 1 ? 0 : 1 );
 
 	// TODO - maybe a warning could be helpful for some mismatches.
 

--- a/tests/locale.js
+++ b/tests/locale.js
@@ -6,15 +6,14 @@
 /* globals console */
 
 import Locale from '../src/locale';
+import {
+	add as addTranslations,
+	_clear as clearTranslations
+} from '../src/translation-service';
 
 describe( 'Locale', () => {
-	let locale;
-
-	beforeEach( () => {
-		locale = new Locale();
-	} );
-
 	afterEach( () => {
+		clearTranslations();
 		sinon.restore();
 	} );
 
@@ -115,35 +114,51 @@ describe( 'Locale', () => {
 	} );
 
 	describe( 't', () => {
-		it( 'has the context bound', () => {
-			const t = locale.t;
+		let locale;
 
-			expect( t( 'Foo' ) ).to.equal( 'Foo' );
+		beforeEach( () => {
+			// eslint-disable-next-line no-nested-ternary
+			const getPolishPluralForm = n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2;
+
+			addTranslations( 'pl', {
+				'foo': 'foo_pl',
+				'bar': [ 'bar_pl_0', '%0 bar_pl_1', '%0 bar_pl_2' ]
+			}, getPolishPluralForm );
+
+			addTranslations( 'de', {
+				'foo': 'foo_de',
+				'bar': [ 'bar_de_0', '%0 bar_de_1', '%0 bar_de_2' ]
+			} );
+
+			locale = new Locale( {
+				uiLanguage: 'pl',
+				contentLanguage: 'de'
+			} );
 		} );
 
-		it( 'interpolates 1 value', () => {
+		it( 'should translate a string to the target ui language', () => {
+			const t = locale.t;
+
+			expect( t( 'foo' ) ).to.equal( 'foo_pl' );
+		} );
+
+		it( 'should translate a plural form to the target ui language based on the first value and interpolate the string', () => {
+			const t = locale.t;
+
+			expect( t( { string: 'bar', plural: '%0 bars' }, [ 1 ] ), 1 ).to.equal( 'bar_pl_0' );
+			expect( t( { string: 'bar', plural: '%0 bars' }, [ 2 ] ), 2 ).to.equal( '2 bar_pl_1' );
+			expect( t( { string: 'bar', plural: '%0 bars' }, [ 5 ] ), 3 ).to.equal( '5 bar_pl_2' );
+		} );
+
+		it( 'should interpolate a message with provided values', () => {
 			const t = locale.t;
 
 			expect( t( '%0 - %0', [ 'foo' ] ) ).to.equal( 'foo - foo' );
-		} );
-
-		it( 'interpolates 3 values', () => {
-			const t = locale.t;
-
 			expect( t( '%1 - %0 - %2', [ 'a', 'b', 'c' ] ) ).to.equal( 'b - a - c' );
-		} );
 
-		// Those test make sure that if %0 is really to be used, then it's going to work.
-		// It'd be a super rare case if one would need to use %0 and at the same time interpolate something.
-		it( 'does not interpolate placeholders if values not passed', () => {
-			const t = locale.t;
-
+			// Those test make sure that if %0 is really to be used, then it's going to work.
+			// It'd be a super rare case if one would need to use %0 and at the same time interpolate something.
 			expect( t( '%1 - %0 - %2' ) ).to.equal( '%1 - %0 - %2' );
-		} );
-
-		it( 'does not interpolate those placeholders for which values has not been passed', () => {
-			const t = locale.t;
-
 			expect( t( '%1 - %0 - %2', [ 'a' ] ) ).to.equal( '%1 - a - %2' );
 		} );
 	} );
@@ -151,6 +166,7 @@ describe( 'Locale', () => {
 	describe( 'language()', () => {
 		it( 'should return #uiLanguage', () => {
 			const stub = sinon.stub( console, 'warn' );
+			const locale = new Locale();
 
 			expect( locale.language ).to.equal( locale.uiLanguage );
 			sinon.assert.calledWithMatch( stub, 'locale-deprecated-language-property' );
@@ -158,6 +174,7 @@ describe( 'Locale', () => {
 
 		it( 'should warn about deprecation', () => {
 			const stub = sinon.stub( console, 'warn' );
+			const locale = new Locale();
 
 			expect( locale.language ).to.equal( 'en' );
 			sinon.assert.calledWithMatch( stub, 'locale-deprecated-language-property' );

--- a/tests/locale.js
+++ b/tests/locale.js
@@ -143,14 +143,15 @@ describe( 'Locale', () => {
 			expect( t( 'foo' ) ).to.equal( 'foo_pl' );
 		} );
 
-		it( 'should translate a message including the message string and the message context', () => {
+		it( 'should translate a message using the message id if it was passed', () => {
 			const t = locale.t;
 
 			addTranslations( 'pl', {
-				'foo_bar': 'foo_bar_pl'
+				'ADD_IMAGE': 'obrazek',
+				'image': 'foo'
 			} );
 
-			expect( t( { string: 'foo', context: 'bar' } ) ).to.equal( 'foo_bar_pl' );
+			expect( t( { string: 'image', id: 'ADD_IMAGE' } ) ).to.equal( 'obrazek' );
 		} );
 
 		it( 'should translate a message supporting plural forms', () => {
@@ -161,16 +162,16 @@ describe( 'Locale', () => {
 			expect( t( { string: 'bar', plural: '%0 bars' }, [ 5 ] ), 3 ).to.equal( '5 bar_pl_2' );
 		} );
 
-		it( 'should translate a message supporting plural forms with a context', () => {
+		it( 'should translate a message supporting plural forms with a message id if it was passed', () => {
 			const t = locale.t;
 
 			addTranslations( 'pl', {
-				'%1 a space_Add/Remove a space': [ '%1 spację', '%1 %0 spacje', '%1 %0 spacji' ],
+				'ADD_SPACE': [ '%1 spację', '%1 %0 spacje', '%1 %0 spacji' ],
 				'Add': 'Dodaj',
 				'Remove': 'Usuń'
 			} );
 
-			const addOrRemoveSpaceMessage = { string: '%1 a space', plural: '%1 %0 spaces', context: 'Add/Remove a space' };
+			const addOrRemoveSpaceMessage = { string: '%1 a space', plural: '%1 %0 spaces', id: 'ADD_SPACE' };
 
 			expect( t( addOrRemoveSpaceMessage, [ 1, t( 'Add' ) ] ), 1 ).to.equal( 'Dodaj spację' );
 			expect( t( addOrRemoveSpaceMessage, [ 2, t( 'Remove' ) ] ), 2 ).to.equal( 'Usuń 2 spacje' );

--- a/tests/locale.js
+++ b/tests/locale.js
@@ -136,10 +136,20 @@ describe( 'Locale', () => {
 			} );
 		} );
 
-		it( 'should translate a string to the target ui language', () => {
+		it( 'should translate a message to the target ui language', () => {
 			const t = locale.t;
 
 			expect( t( 'foo' ) ).to.equal( 'foo_pl' );
+		} );
+
+		it( 'should translate a message including the message string and the message context', () => {
+			const t = locale.t;
+
+			addTranslations( 'pl', {
+				'foo_bar': 'foo_bar_pl'
+			} );
+
+			expect( t( { string: 'foo', context: 'bar' } ) ).to.equal( 'foo_bar_pl' );
 		} );
 
 		it( 'should translate a plural form to the target ui language based on the first value and interpolate the string', () => {
@@ -148,6 +158,22 @@ describe( 'Locale', () => {
 			expect( t( { string: 'bar', plural: '%0 bars' }, [ 1 ] ), 1 ).to.equal( 'bar_pl_0' );
 			expect( t( { string: 'bar', plural: '%0 bars' }, [ 2 ] ), 2 ).to.equal( '2 bar_pl_1' );
 			expect( t( { string: 'bar', plural: '%0 bars' }, [ 5 ] ), 3 ).to.equal( '5 bar_pl_2' );
+		} );
+
+		it( 'should translate a message supporting plural form with a context', () => {
+			const t = locale.t;
+
+			addTranslations( 'pl', {
+				'%1 a space_Add/Remove a space': [ '%1 spację', '%1 %0 spacje', '%1 %0 spacji' ],
+				'Add': 'Dodaj',
+				'Remove': 'Usuń'
+			} );
+
+			const addOrRemoveSpaceMessage = { string: '%1 a space', plural: '%1 %0 spaces', context: 'Add/Remove a space' };
+
+			expect( t( addOrRemoveSpaceMessage, [ 1, t( 'Add' ) ] ), 1 ).to.equal( 'Dodaj spację' );
+			expect( t( addOrRemoveSpaceMessage, [ 2, t( 'Remove' ) ] ), 2 ).to.equal( 'Usuń 2 spacje' );
+			expect( t( addOrRemoveSpaceMessage, [ 5, t( 'Add' ) ] ), 3 ).to.equal( 'Dodaj 5 spacji' );
 		} );
 
 		it( 'should interpolate a message with provided values', () => {

--- a/tests/locale.js
+++ b/tests/locale.js
@@ -203,11 +203,11 @@ describe( 'Locale', () => {
 
 			expectToThrowCKEditorError( () => {
 				t( { string: 'Add space', plural: 'Add %0 spaces' }, 'space' );
-			}, /translation-service-amount-not-a-number:/, null, { amount: 'space' } );
+			}, /translation-service-quantity-not-a-number:/, null, { quantity: 'space' } );
 
 			expectToThrowCKEditorError( () => {
 				t( { string: 'Add space', plural: 'Add %0 spaces' }, [ 'space' ] );
-			}, /translation-service-amount-not-a-number:/, null, { amount: 'space' } );
+			}, /translation-service-quantity-not-a-number:/, null, { quantity: 'space' } );
 
 			expect( () => {
 				t( { string: 'Add space', plural: 'Add %0 spaces' }, [ 3 ] );

--- a/tests/translation-service.js
+++ b/tests/translation-service.js
@@ -46,7 +46,7 @@ describe( 'translation-service', () => {
 		} );
 	} );
 
-	describe( 'translate()', () => {
+	describe( '_translate()', () => {
 		it( 'should return translated messages when translations are defined', () => {
 			add( 'pl', {
 				'OK': 'OK',

--- a/tests/translation-service.js
+++ b/tests/translation-service.js
@@ -46,24 +46,39 @@ describe( 'translation-service', () => {
 	} );
 
 	describe( 'translate()', () => {
-		it( 'should return the message string if no translation exists', () => {
-			const translatedBold = translate( 'pl', { string: 'Bold' } );
-
-			expect( translatedBold ).to.be.equal( 'Bold' );
-		} );
-
-		it( 'should return a translation if it is defined in the target language dictionary', () => {
+		it( 'should return translated messages when translations are defined', () => {
 			add( 'pl', {
 				'OK': 'OK',
 				'Cancel': 'Anuluj'
 			} );
 
-			const translatedCancel = translate( 'pl', { string: 'Cancel' } );
+			add( 'en_US', {
+				'OK': 'OK',
+				'Cancel': 'Cancel'
+			} );
 
-			expect( translatedCancel ).to.be.equal( 'Anuluj' );
+			const translatedCancelPL = translate( 'pl', { string: 'Cancel' } );
+			const translatedCancelEN = translate( 'en', { string: 'Cancel' } );
+
+			expect( translatedCancelPL ).to.be.equal( 'Anuluj' );
+			expect( translatedCancelEN ).to.be.equal( 'Cancel' );
 		} );
 
-		it( 'should return the message string if a translation for the target language does not exist' +
+		it( 'should return the original message string if no translation exists for the given message', () => {
+			const translatedBold = translate( 'pl', { string: 'Bold' } );
+
+			expect( translatedBold ).to.be.equal( 'Bold' );
+		} );
+
+		it( 'should return the correct plural form of english message if no translation exists for the given message', () => {
+			const addSpaces = translate( 'pl', { string: 'Add a space', plural: 'Add %0 spaces' }, 3 );
+			const addASpace = translate( 'pl', { string: 'Add a space', plural: 'Add %0 spaces' }, 1 );
+
+			expect( addSpaces ).to.be.equal( 'Add %0 spaces' );
+			expect( addASpace ).to.be.equal( 'Add a space' );
+		} );
+
+		it( 'should return the original message string if a translation for the target language does not exist' +
 			'but translation doesn\'t', () => {
 				add( 'pl', {
 					'OK': 'OK',
@@ -86,25 +101,7 @@ describe( 'translation-service', () => {
 			expect( translatedCancel ).to.be.equal( 'Anuluj' );
 		} );
 
-		it( 'should return translated messages when translations are defined', () => {
-			add( 'pl', {
-				'OK': 'OK',
-				'Cancel': 'Anuluj'
-			} );
-
-			add( 'en_US', {
-				'OK': 'OK',
-				'Cancel': 'Cancel'
-			} );
-
-			const translatedCancelPL = translate( 'pl', { string: 'Cancel' } );
-			const translatedCancelEN = translate( 'en', { string: 'Cancel' } );
-
-			expect( translatedCancelPL ).to.be.equal( 'Anuluj' );
-			expect( translatedCancelEN ).to.be.equal( 'Cancel' );
-		} );
-
-		it( 'should construct message id from message string and message context when both are provided', () => {
+		it( 'should return a translated message based on message string and message context when both are provided', () => {
 			add( 'pl', {
 				'foo_bar': 'foo-bar-translation',
 			} );
@@ -125,7 +122,7 @@ describe( 'translation-service', () => {
 			expect( translation ).to.equal( 'Anuluj' );
 		} );
 
-		it( 'should return the correct plural form of the translation', () => {
+		it( 'should return the correct plural form of the message based on the provided function', () => {
 			add( 'pl', {
 				'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ],
 				'Cancel': 'Anuluj'
@@ -135,6 +132,18 @@ describe( 'translation-service', () => {
 			expect( translate( 'pl', 'Add space', 1 ) ).to.equal( 'Dodaj spację' );
 			expect( translate( 'pl', 'Add space', 3 ) ).to.equal( 'Dodaj %0 spacje' );
 			expect( translate( 'pl', 'Add space', 13 ) ).to.equal( 'Dodaj %0 spacji' );
+		} );
+
+		it( 'should return a plural form based on rules for English if no function to determine the plural form was provided', () => {
+			add( 'pl', {
+				'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ],
+				'Cancel': 'Anuluj'
+			} );
+
+			expect( translate( 'pl', 'Add space', 0 ) ).to.equal( 'Dodaj %0 spacje' );
+			expect( translate( 'pl', 'Add space', 1 ) ).to.equal( 'Dodaj spację' );
+			expect( translate( 'pl', 'Add space', 3 ) ).to.equal( 'Dodaj %0 spacje' );
+			expect( translate( 'pl', 'Add space', 13 ) ).to.equal( 'Dodaj %0 spacje' );
 		} );
 	} );
 } );

--- a/tests/translation-service.js
+++ b/tests/translation-service.js
@@ -102,14 +102,14 @@ describe( 'translation-service', () => {
 			expect( translatedCancel ).to.be.equal( 'Anuluj' );
 		} );
 
-		it( 'should return a translated message based on message string and message context when both are provided', () => {
+		it( 'should return a translated message based on message id when it was passed', () => {
 			add( 'pl', {
-				'foo_bar': 'foo-bar-translation'
+				'ADD_IMAGE': 'obraz'
 			} );
 
-			const translatedFooBar = _translate( 'pl', { string: 'foo', context: 'bar' } );
+			const translatedFooBar = _translate( 'pl', { string: 'image', id: 'ADD_IMAGE' } );
 
-			expect( translatedFooBar ).to.equal( 'foo-bar-translation' );
+			expect( translatedFooBar ).to.equal( 'obraz' );
 		} );
 
 		it( 'should return the correct plural form of the message based on the provided function', () => {

--- a/tests/translation-service.js
+++ b/tests/translation-service.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import { translate, add, _clear } from '../src/translation-service';
+import { _translate, add, _clear } from '../src/translation-service';
 
 describe( 'translation-service', () => {
 	afterEach( () => {
@@ -15,8 +15,8 @@ describe( 'translation-service', () => {
 			add( 'pl', { 'foo': 'foo_pl' } );
 			add( 'pl', { 'bar': 'bar_pl' } );
 
-			const translatedFoo = translate( 'pl', { string: 'foo' } );
-			const translatedBar = translate( 'pl', { string: 'bar' } );
+			const translatedFoo = _translate( 'pl', { string: 'foo' } );
+			const translatedBar = _translate( 'pl', { string: 'bar' } );
 
 			expect( translatedFoo ).to.equal( 'foo_pl' );
 			expect( translatedBar ).to.equal( 'bar_pl' );
@@ -26,7 +26,7 @@ describe( 'translation-service', () => {
 			add( 'pl', { 'foo': 'First' } );
 			add( 'pl', { 'foo': 'Second' } );
 
-			const translatedFoo = translate( 'pl', { string: 'foo' } );
+			const translatedFoo = _translate( 'pl', { string: 'foo' } );
 
 			expect( translatedFoo ).to.equal( 'Second' );
 		} );
@@ -39,10 +39,10 @@ describe( 'translation-service', () => {
 			// eslint-disable-next-line no-nested-ternary
 			add( 'pl', {}, n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 );
 
-			expect( translate( 'pl', 'Add space', 0 ) ).to.equal( 'Dodaj %0 spacji' );
-			expect( translate( 'pl', 'Add space', 1 ) ).to.equal( 'Dodaj spację' );
-			expect( translate( 'pl', 'Add space', 3 ) ).to.equal( 'Dodaj %0 spacje' );
-			expect( translate( 'pl', 'Add space', 13 ) ).to.equal( 'Dodaj %0 spacji' );
+			expect( _translate( 'pl', { string: 'Add space' }, 0 ) ).to.equal( 'Dodaj %0 spacji' );
+			expect( _translate( 'pl', { string: 'Add space' }, 1 ) ).to.equal( 'Dodaj spację' );
+			expect( _translate( 'pl', { string: 'Add space' }, 3 ) ).to.equal( 'Dodaj %0 spacje' );
+			expect( _translate( 'pl', { string: 'Add space' }, 13 ) ).to.equal( 'Dodaj %0 spacji' );
 		} );
 	} );
 
@@ -58,35 +58,35 @@ describe( 'translation-service', () => {
 				'Cancel': 'Cancel'
 			} );
 
-			const translatedCancelPL = translate( 'pl', { string: 'Cancel' } );
-			const translatedCancelEN = translate( 'en', { string: 'Cancel' } );
+			const translatedCancelPL = _translate( 'pl', { string: 'Cancel' } );
+			const translatedCancelEN = _translate( 'en', { string: 'Cancel' } );
 
 			expect( translatedCancelPL ).to.be.equal( 'Anuluj' );
 			expect( translatedCancelEN ).to.be.equal( 'Cancel' );
 		} );
 
 		it( 'should return the original message string if no translation exists for the given message', () => {
-			const translatedBold = translate( 'pl', { string: 'Bold' } );
+			const translatedBold = _translate( 'pl', { string: 'Bold' } );
 
 			expect( translatedBold ).to.be.equal( 'Bold' );
 		} );
 
 		it( 'should return the correct plural form of english message if no translation exists for the given message', () => {
-			const addSpaces = translate( 'pl', { string: 'Add a space', plural: 'Add %0 spaces' }, 3 );
-			const addASpace = translate( 'pl', { string: 'Add a space', plural: 'Add %0 spaces' }, 1 );
+			const addSpaces = _translate( 'pl', { string: 'Add a space', plural: 'Add %0 spaces' }, 3 );
+			const addASpace = _translate( 'pl', { string: 'Add a space', plural: 'Add %0 spaces' }, 1 );
 
 			expect( addSpaces ).to.be.equal( 'Add %0 spaces' );
 			expect( addASpace ).to.be.equal( 'Add a space' );
 		} );
 
 		it( 'should return the original message string if a translation for the target language does not exist' +
-			'but translation doesn\'t', () => {
+		'but translation doesn\'t', () => {
 			add( 'pl', {
 				'OK': 'OK',
 				'Cancel': 'Anuluj'
 			} );
 
-			const translatedBold = translate( 'pl', { string: 'Bold' } );
+			const translatedBold = _translate( 'pl', { string: 'Bold' } );
 
 			expect( translatedBold ).to.be.equal( 'Bold' );
 		} );
@@ -97,7 +97,7 @@ describe( 'translation-service', () => {
 				'Cancel': 'Anuluj'
 			} );
 
-			const translatedCancel = translate( 'de', { string: 'Cancel' } );
+			const translatedCancel = _translate( 'de', { string: 'Cancel' } );
 
 			expect( translatedCancel ).to.be.equal( 'Anuluj' );
 		} );
@@ -107,20 +107,9 @@ describe( 'translation-service', () => {
 				'foo_bar': 'foo-bar-translation'
 			} );
 
-			const translatedFooBar = translate( 'pl', { string: 'foo', context: 'bar' } );
+			const translatedFooBar = _translate( 'pl', { string: 'foo', context: 'bar' } );
 
 			expect( translatedFooBar ).to.equal( 'foo-bar-translation' );
-		} );
-
-		it( 'should support a deprecated form of using translate() function with string as a message', () => {
-			add( 'pl', {
-				'OK': 'OK',
-				'Cancel': 'Anuluj'
-			} );
-
-			const translation = translate( 'pl', 'Cancel' );
-
-			expect( translation ).to.equal( 'Anuluj' );
 		} );
 
 		it( 'should return the correct plural form of the message based on the provided function', () => {
@@ -130,10 +119,10 @@ describe( 'translation-service', () => {
 				// eslint-disable-next-line no-nested-ternary
 			}, n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 );
 
-			expect( translate( 'pl', 'Add space', 0 ) ).to.equal( 'Dodaj %0 spacji' );
-			expect( translate( 'pl', 'Add space', 1 ) ).to.equal( 'Dodaj spację' );
-			expect( translate( 'pl', 'Add space', 3 ) ).to.equal( 'Dodaj %0 spacje' );
-			expect( translate( 'pl', 'Add space', 13 ) ).to.equal( 'Dodaj %0 spacji' );
+			expect( _translate( 'pl', { string: 'Add space' }, 0 ) ).to.equal( 'Dodaj %0 spacji' );
+			expect( _translate( 'pl', { string: 'Add space' }, 1 ) ).to.equal( 'Dodaj spację' );
+			expect( _translate( 'pl', { string: 'Add space' }, 3 ) ).to.equal( 'Dodaj %0 spacje' );
+			expect( _translate( 'pl', { string: 'Add space' }, 13 ) ).to.equal( 'Dodaj %0 spacji' );
 		} );
 
 		it( 'should return a plural form based on rules for English if no function to determine the plural form was provided', () => {
@@ -142,10 +131,11 @@ describe( 'translation-service', () => {
 				'Cancel': 'Anuluj'
 			} );
 
-			expect( translate( 'pl', 'Add space', 0 ) ).to.equal( 'Dodaj %0 spacje' );
-			expect( translate( 'pl', 'Add space', 1 ) ).to.equal( 'Dodaj spację' );
-			expect( translate( 'pl', 'Add space', 3 ) ).to.equal( 'Dodaj %0 spacje' );
-			expect( translate( 'pl', 'Add space', 13 ) ).to.equal( 'Dodaj %0 spacje' );
+			expect( _translate( 'pl', { string: 'Add space' }, 1 ) ).to.equal( 'Dodaj spację' );
+
+			expect( _translate( 'pl', { string: 'Add space' }, 0 ) ).to.equal( 'Dodaj %0 spacje' );
+			expect( _translate( 'pl', { string: 'Add space' }, 3 ) ).to.equal( 'Dodaj %0 spacje' );
+			expect( _translate( 'pl', { string: 'Add space' }, 13 ) ).to.equal( 'Dodaj %0 spacje' );
 		} );
 	} );
 } );

--- a/tests/translation-service.js
+++ b/tests/translation-service.js
@@ -137,5 +137,18 @@ describe( 'translation-service', () => {
 			expect( _translate( 'pl', { string: 'Add space' }, 3 ) ).to.equal( 'Dodaj %0 spacje' );
 			expect( _translate( 'pl', { string: 'Add space' }, 13 ) ).to.equal( 'Dodaj %0 spacje' );
 		} );
+
+		it( 'should support a plural form rule that returns a boolean', () => {
+			add( 'pl', {
+				'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje' ],
+				'Cancel': 'Anuluj'
+			}, n => n !== 1 );
+
+			expect( _translate( 'pl', { string: 'Add space' }, 1 ) ).to.equal( 'Dodaj spację' );
+
+			expect( _translate( 'pl', { string: 'Add space' }, 0 ) ).to.equal( 'Dodaj %0 spacje' );
+			expect( _translate( 'pl', { string: 'Add space' }, 3 ) ).to.equal( 'Dodaj %0 spacje' );
+			expect( _translate( 'pl', { string: 'Add space' }, 13 ) ).to.equal( 'Dodaj %0 spacje' );
+		} );
 	} );
 } );

--- a/tests/translation-service.js
+++ b/tests/translation-service.js
@@ -33,9 +33,10 @@ describe( 'translation-service', () => {
 
 		it( 'should set the plural form function if it is provided', () => {
 			add( 'pl', {
-				'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ],
+				'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ]
 			} );
 
+			// eslint-disable-next-line no-nested-ternary
 			add( 'pl', {}, n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 );
 
 			expect( translate( 'pl', 'Add space', 0 ) ).to.equal( 'Dodaj %0 spacji' );
@@ -80,15 +81,15 @@ describe( 'translation-service', () => {
 
 		it( 'should return the original message string if a translation for the target language does not exist' +
 			'but translation doesn\'t', () => {
-				add( 'pl', {
-					'OK': 'OK',
-					'Cancel': 'Anuluj'
-				} );
-
-				const translatedBold = translate( 'pl', { string: 'Bold' } );
-
-				expect( translatedBold ).to.be.equal( 'Bold' );
+			add( 'pl', {
+				'OK': 'OK',
+				'Cancel': 'Anuluj'
 			} );
+
+			const translatedBold = translate( 'pl', { string: 'Bold' } );
+
+			expect( translatedBold ).to.be.equal( 'Bold' );
+		} );
 
 		it( 'should return a translated message when only one language is provided', () => {
 			add( 'pl', {
@@ -103,7 +104,7 @@ describe( 'translation-service', () => {
 
 		it( 'should return a translated message based on message string and message context when both are provided', () => {
 			add( 'pl', {
-				'foo_bar': 'foo-bar-translation',
+				'foo_bar': 'foo-bar-translation'
 			} );
 
 			const translatedFooBar = translate( 'pl', { string: 'foo', context: 'bar' } );
@@ -126,6 +127,7 @@ describe( 'translation-service', () => {
 			add( 'pl', {
 				'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ],
 				'Cancel': 'Anuluj'
+				// eslint-disable-next-line no-nested-ternary
 			}, n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 );
 
 			expect( translate( 'pl', 'Add space', 0 ) ).to.equal( 'Dodaj %0 spacji' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Provided support for plural forms internalization. Part of ckeditor/ckeditor5#6526.

MINOR BREAKING CHANGE: The `translate` function from the `translation-service` was marked as protected. See #334.
MINOR BREAKING CHANGE: The format of translations added to the editor has been changed. If you use `window.CKEDITOR_TRANSLATIONS` please see #334.

---

### Additional information

The `translate` function in the `translation-service` was marked as protected and renamed to `_translate`. All features depending on the translation mechanism should use the `Locale#t()` function instead.

The new format of the  `window.CKEDITOR_TRANSLATIONS`:
```js
{
   pl: {
      dictionary: {
         'Cancel': 'Anuluj',
         'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ]
      }, 
      // A function that returns the plural form index.
      // Actually it's more like n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2
      getPluralForm: n => n !==1
   }
   // other languages...
}
```
